### PR TITLE
Add Tabs and SelectionType UI components

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -33,5 +33,7 @@ export { Textarea, type TextareaProps } from "./textarea";
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
 export { Toggle } from './toggle'
 export { ToggleGroup, ToggleGroupItem } from './toggle-group'
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants } from './tabs'
+export { SelectionType, SelectionItem, selectionItemVariants } from './selection-type'
 
 

--- a/src/components/ui/selection-type.tsx
+++ b/src/components/ui/selection-type.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const selectionItemVariants = cva(
+  "flex items-center justify-between gap-3 rounded-lg border text-sm font-medium transition-all hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+  {
+    variants: {
+      variant: {
+        default: "border-input bg-background text-foreground",
+        selected: "border-primary bg-background text-foreground",
+      },
+      size: {
+        sm: "h-10 px-3 py-2",
+        md: "h-11 px-4 py-2.5",
+        lg: "h-12 px-4 py-3",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  }
+);
+
+interface SelectionTypeContextValue {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+const SelectionTypeContext = React.createContext<SelectionTypeContextValue>({});
+
+interface SelectionTypeProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+function SelectionType({
+  className,
+  value,
+  onValueChange,
+  children,
+  ...props
+}: SelectionTypeProps) {
+  return (
+    <SelectionTypeContext.Provider value={{ value, onValueChange }}>
+      <div
+        className={cn("flex flex-col gap-3 rounded-lg border border-dashed border-muted p-4", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </SelectionTypeContext.Provider>
+  );
+}
+
+interface SelectionItemProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof selectionItemVariants> {
+  value: string;
+  icon?: React.ReactNode;
+  endIcon?: React.ReactNode;
+}
+
+function SelectionItem({
+  className,
+  variant,
+  size = "md",
+  value,
+  icon,
+  endIcon,
+  children,
+  onClick,
+  ...props
+}: SelectionItemProps) {
+  const context = React.useContext(SelectionTypeContext);
+  const isSelected = context.value === value;
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    context.onValueChange?.(value);
+    onClick?.(e);
+  };
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        selectionItemVariants({ variant: isSelected ? "selected" : variant, size }),
+        className
+      )}
+      onClick={handleClick}
+      {...props}
+    >
+      {icon && (
+        <span className={cn("shrink-0", isSelected ? "text-primary" : "text-muted-foreground")}>
+          {icon}
+        </span>
+      )}
+      <span className="flex-1 text-left">{children}</span>
+      {endIcon && (
+        <span className={cn("shrink-0", isSelected ? "text-primary" : "text-muted-foreground")}>
+          {endIcon}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export { SelectionType, SelectionItem, selectionItemVariants };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,80 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "gap-3.75 group/tabs flex flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "rounded-lg p-[3px] group-data-horizontal/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
+        "after:bg-primary after:absolute after:opacity-0 after:transition-opacity after:inset-x-0 after:bottom-0 after:h-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100 group-data-[variant=line]/tabs-list:data-active:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("text-sm flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,14 @@ export {
     Toggle,
     ToggleGroup,
     ToggleGroupItem,
+    // Tabs
+    Tabs,
+    TabsList,
+    TabsTrigger,
+    TabsContent,
+    // Selection Type
+    SelectionType,
+    SelectionItem,
     // Types
     type AlertProps,
     type AlertVariant,


### PR DESCRIPTION
Introduce new UI components: Tabs and SelectionType. Adds src/components/ui/tabs.tsx (Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants) and src/components/ui/selection-type.tsx (SelectionType, SelectionItem, selectionItemVariants with context and cva variants). Update component barrel exports in src/components/ui/index.ts and the package export list in src/index.ts to expose the new components.

Close #8 
**Description:** 
Add Tabs and SelectionType components to plugin-ui library

This branch introduces two new UI components following the existing design system pattern:

**Tabs Component (tabs.tsx)**

- Built on @base-ui/react TabsPrimitive
- Supports two variants: "default" (with background) and "line" (with underline indicator)
- Active tab shows primary color with animated underline for line variant
- Flexible layout with content displayed below tabs
- Customizable gap spacing (default: 15px)
- SelectionType Component (selection-type.tsx)
- Custom card-style selection component for choosing between options
- Uses React Context for state management
- Dynamic icon colors (primary when selected, muted-foreground when not)
- Three size variants: sm (h-10), md (h-11), lg (h-12)
- Supports custom icons on both left and right sides

**Technical Implementation:**
1. Uses class-variance-authority for variant management
2. Semantic color tokens (primary, secondary, muted, etc.)
3. Follows existing component patterns with @base-ui/react primitives
4. Properly exported from component index and main package index

Files Changed:
- src/components/ui/tabs.tsx (new)
- src/components/ui/selection-type.tsx (new)
- src/components/ui/index.ts (exports added)
- src/index.ts (exports added)
