### PR TITLE
Refactor inputs, add OTP & update group API

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "@base-ui/react": "^1.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "input-otp": "^1.4.2",
         "lucide-react": "^0.563.0",
         "tailwind-merge": "^2.6.1",
         "tw-animate-css": "^1.4.0"

--- a/src/components/ui/currency-input.tsx
+++ b/src/components/ui/currency-input.tsx
@@ -5,7 +5,11 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
-import { InputGroup } from "./input-group";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "./input-group";
 
 /** Chevron-down icon for dropdowns */
 function ChevronDownIcon({ className }: { className?: string }) {
@@ -57,11 +61,6 @@ export interface CurrencyInputProps
   placeholder?: string;
 
   /**
-   * Error state for the whole component.
-   */
-  error?: boolean;
-
-  /**
    * Additional CSS classes for the root wrapper.
    */
   className?: string;
@@ -99,7 +98,6 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
       onCurrencyChange,
       currencyOptions = DEFAULT_CURRENCIES,
       placeholder = "Type something",
-      error = false,
       className,
       currencySelector,
       disabled,
@@ -112,7 +110,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
     const inputId = idProp ?? id;
     const selectId = `${id}-currency`;
 
-    const rightAddon =
+    const currencySelectorContent =
       currencySelector != null ? (
         currencySelector
       ) : (
@@ -126,7 +124,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
             onChange={(e) => onCurrencyChange?.(e.target.value)}
             disabled={disabled}
             className={cn(
-              "h-full min-w-18 cursor-pointer appearance-none bg-transparent pl-3 pr-8 py-2 text-sm font-medium text-foreground outline-none",
+              "h-full min-w-18 cursor-pointer appearance-none bg-transparent pl-3 pr-8 py-2 text-sm font-medium text-foreground outline-none border-0",
               "disabled:cursor-not-allowed disabled:opacity-50",
             )}
             aria-label="Currency"
@@ -147,19 +145,21 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
       );
 
     return (
-      <InputGroup
-        ref={ref}
-        id={inputId}
-        type="text"
-        inputMode="decimal"
-        placeholder={placeholder}
-        disabled={disabled}
-        error={error}
-        className={className}
-        rightAddon={rightAddon}
-        aria-describedby={selectId}
-        {...inputProps}
-      />
+      <InputGroup className={className} data-disabled={disabled || undefined}>
+        <InputGroupInput
+          ref={ref}
+          id={inputId}
+          type="text"
+          inputMode="decimal"
+          placeholder={placeholder}
+          disabled={disabled}
+          aria-describedby={selectId}
+          {...inputProps}
+        />
+        <InputGroupAddon align="inline-end">
+          {currencySelectorContent}
+        </InputGroupAddon>
+      </InputGroup>
     );
   },
 );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,8 +13,21 @@ export {
   type CurrencyInputProps,
   type CurrencyOption,
 } from "./currency-input";
-export { Input, type InputProps } from "./input";
-export { InputGroup, type InputGroupProps } from "./input-group";
+export { Input } from "./input";
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+} from "./input-group";
+export {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  InputOTPSeparator,
+} from "./input-otp";
 export { Label, type LabelProps } from "./label";
 export {
     Modal, ModalClose, ModalContent, ModalDescription,
@@ -29,7 +42,7 @@ export {
 export { Separator, type SeparatorProps } from "./separator";
 export { Spinner } from "./spinner";
 export { Switch, type SwitchProps } from "./switch";
-export { Textarea, type TextareaProps } from "./textarea";
+export { Textarea } from "./textarea";
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
 export { Toggle } from './toggle'
 export { ToggleGroup, ToggleGroupItem } from './toggle-group'

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,125 +1,149 @@
-import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
-import { cn } from "@/lib/utils";
-import { Input } from "./input";
+"use client"
 
-export interface InputGroupProps extends InputHTMLAttributes<HTMLInputElement> {
-  /**
-   * Content to show on the left of the input (e.g. icon, prefix, select).
-   */
-  leftAddon?: ReactNode;
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
 
-  /**
-   * Content to show on the right of the input (e.g. icon, suffix, select).
-   */
-  rightAddon?: ReactNode;
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 
-  /**
-   * Error state for the whole group.
-   */
-  error?: boolean;
-
-  /**
-   * Additional CSS classes for the root wrapper.
-   */
-  className?: string;
-
-  /**
-   * Additional CSS classes for the inner input element.
-   */
-  inputClassName?: string;
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-9 rounded-md border shadow-xs transition-[color,box-shadow] in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-/**
- * Generic input with optional left and right addons in a single bordered box.
- * Addons are rendered with muted background and a border between them and the input.
- *
- * @example
- * ```tsx
- * // Left addon (prefix)
- * <InputGroup
- *   leftAddon={<span className="px-3 text-muted-foreground">$</span>}
- *   placeholder="0.00"
- * />
- *
- * // Right addon (suffix / currency)
- * <InputGroup
- *   rightAddon={(
- *     <select className="...">
- *       <option>USD</option>
- *     </select>
- *   )}
- *   placeholder="Amount"
- * />
- *
- * // Both
- * <InputGroup
- *   leftAddon={<SearchIcon />}
- *   rightAddon={<Button size="icon">...</Button>}
- *   placeholder="Search"
- * />
- * ```
- */
-export const InputGroup = forwardRef<HTMLInputElement, InputGroupProps>(
-  (
-    {
-      leftAddon,
-      rightAddon,
-      error = false,
-      className,
-      inputClassName,
-      disabled,
-      ...inputProps
+const inputGroupAddonVariants = cva(
+  "text-muted-foreground h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4 flex cursor-text items-center justify-center select-none",
+  {
+    variants: {
+      align: {
+        "inline-start": "pl-2 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem] order-first",
+        "inline-end": "pr-2 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem] order-last",
+        "block-start":
+          "px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2 order-first w-full justify-start",
+        "block-end":
+          "px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2 order-last w-full justify-start",
+      },
     },
-    ref,
-  ) => {
-    const hasLeft = leftAddon != null;
-    const hasRight = rightAddon != null;
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
 
-    return (
-      <div
-        className={cn(
-          "flex h-9 w-full overflow-hidden rounded-md border bg-transparent text-base shadow-sm transition-colors md:text-sm",
-          "focus-within:ring-1 focus-within:ring-ring",
-          error
-            ? "border-destructive focus-within:ring-destructive"
-            : "border-input",
-          disabled && "cursor-not-allowed opacity-50",
-          className,
-        )}
-        data-pui-input-group
-      >
-        {hasLeft && (
-          <div
-            className={cn(
-              "flex shrink-0 items-center border-r border-input bg-muted text-muted-foreground",
-              "[&_select]:h-full [&_select]:min-w-0 [&_select]:border-0 [&_select]:bg-transparent [&_select]:outline-none",
-            )}
-          >
-            {leftAddon}
-          </div>
-        )}
-        <Input
-          ref={ref}
-          inGroup
-          disabled={disabled}
-          className={inputClassName}
-          {...inputProps}
-        />
-        {hasRight && (
-          <div
-            className={cn(
-              "flex shrink-0 items-center border-l border-input bg-muted text-muted-foreground",
-              "[&_select]:h-full [&_select]:min-w-0 [&_select]:border-0 [&_select]:bg-transparent [&_select]:outline-none",
-            )}
-          >
-            {rightAddon}
-          </div>
-        )}
-      </div>
-    );
-  },
-);
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
 
-InputGroup.displayName = "InputGroup";
+const inputGroupButtonVariants = cva(
+  "gap-2 text-sm shadow-none flex items-center",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs": "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
 
-export default InputGroup;
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: "button" | "submit" | "reset"
+  }) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn("rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1", className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn("rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1 resize-none", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+
+import { cn } from "@/lib/utils"
+import { MinusIcon } from "lucide-react"
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "cn-input-otp flex items-center has-disabled:opacity-50",
+        containerClassName
+      )}
+      spellCheck={false}
+      className={cn(
+        "disabled:cursor-not-allowed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive rounded-md has-aria-invalid:ring-3 flex items-center", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "dark:bg-input/30 border-input data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive size-9 border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:ring-3 relative flex items-center justify-center data-[active=true]:z-10",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground duration-1000 h-4 w-px" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-separator"
+      className="[&_svg:not([class*='size-'])]:size-4 flex items-center"
+      role="separator"
+      {...props}
+    >
+      <MinusIcon
+      />
+    </div>
+  )
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,72 +1,20 @@
-import { forwardRef, type InputHTMLAttributes } from "react";
-import { cn } from "@/lib/utils";
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
-  /**
-   * Error state
-   */
-  error?: boolean;
+import { cn } from "@/lib/utils"
 
-  /**
-   * When true, omits border, radius and focus ring so the input fits inside
-   * InputGroup (the group provides the border and focus-within ring).
-   */
-  inGroup?: boolean;
-
-  /**
-   * Additional CSS classes
-   */
-  className?: string;
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-/**
- * Input component following ShadCN pattern
- *
- * @example
- * ```tsx
- * // Basic usage
- * <Input placeholder="Enter your email" />
- *
- * // With type
- * <Input type="email" placeholder="Email" />
- * <Input type="password" placeholder="Password" />
- *
- * // Error state
- * <Input error placeholder="Invalid input" />
- *
- * // Disabled
- * <Input disabled placeholder="Disabled" />
- * ```
- */
-export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = "text", error, inGroup = false, ...props }, ref) => {
-    return (
-      <input
-        ref={ref}
-        type={type}
-        className={cn(
-          "flex h-9 w-full bg-transparent px-3 py-1 text-base transition-colors duration-150",
-          "file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
-          "placeholder:text-muted-foreground",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "md:text-sm",
-          inGroup
-            ? "min-w-0 border-0 outline-none"
-            : cn(
-                "rounded-md border shadow-sm",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                error
-                  ? "border-destructive focus-visible:ring-destructive"
-                  : "border-input",
-              ),
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
-
-Input.displayName = "Input";
-
-export default Input;
+export { Input }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,60 +1,18 @@
-import { forwardRef, type TextareaHTMLAttributes } from "react";
-import { cn } from "@/lib/utils";
+import * as React from "react"
 
-export interface TextareaProps
-  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
-  /**
-   * Error state
-   */
-  error?: boolean;
+import { cn } from "@/lib/utils"
 
-  /**
-   * Additional CSS classes
-   */
-  className?: string;
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] focus-visible:ring-3 aria-invalid:ring-3 md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-/**
- * Textarea component following ShadCN pattern
- *
- * @example
- * ```tsx
- * // Basic usage
- * <Textarea placeholder="Type your message here." />
- *
- * // With rows
- * <Textarea rows={6} placeholder="Write a detailed description..." />
- *
- * // Error state
- * <Textarea error placeholder="Invalid content" />
- *
- * // Disabled
- * <Textarea disabled placeholder="Cannot edit" />
- * ```
- */
-export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, error, ...props }, ref) => {
-    return (
-      <textarea
-        ref={ref}
-        className={cn(
-          "flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm",
-          "transition-colors duration-150",
-          "placeholder:text-muted-foreground",
-          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "md:text-sm",
-          error
-            ? "border-destructive focus-visible:ring-destructive"
-            : "border-input",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
-
-Textarea.displayName = "Textarea";
-
-export default Textarea;
+export { Textarea }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,16 @@ export {
     // Input
     Input,
     InputGroup,
+    InputGroupAddon,
+    InputGroupButton,
+    InputGroupInput,
+    InputGroupText,
+    InputGroupTextarea,
+    // Input OTP
+    InputOTP,
+    InputOTPGroup,
+    InputOTPSeparator,
+    InputOTPSlot,
     // Label
     Label,
     // Modal
@@ -67,11 +77,8 @@ export {
     type CurrencyInputProps,
     type CurrencyOption,
     type DesignSystemSectionProps,
-    type InputGroupProps,
-    type InputProps,
     type LabelProps, type ModalProps, type SeparatorProps,
-    type SwitchProps,
-    type TextareaProps
+    type SwitchProps
 } from "./components/ui";
 
 // ============================================


### PR DESCRIPTION
Migrate and restructure input-related UI primitives:  (close #10)

- Introduce a new modular InputGroup implementation with slot-based children and helpers: `InputGroup`, `InputGroupAddon`, `InputGroupButton`, `InputGroupText`, `InputGroupInput`, `InputGroupTextarea`.
- Refactor `Input` and `Textarea` to use shared primitives (base input) and simplified props/styles.
- Update `CurrencyInput` to use the new InputGroup slots (`InputGroupInput` + `InputGroupAddon`), remove the group-level `error` prop, and adjust styling.
- Add OTP components by integrating the `input-otp` package: `InputOTP`, `InputOTPGroup`, `InputOTPSlot`, `InputOTPSeparator` and add `input-otp` to package.json.
- Update UI exports to expose the new components and remove some legacy type exports (e.g. `InputProps`, `InputGroupProps`, `TextareaProps`) where the underlying implementations changed.

These changes consolidate input behavior, enable slot composition, and add OTP support for authentication/verification flows.

Enhance input showcase with design improvements and accessibility

- Restructure InputShowcase to match ButtonShowcase hierarchical pattern
- Update currency inputs to use InputGroup with integrated addons
- Add resizable rich text editor with functional toolbar
- Implement tag input with Enter/Backspace keyboard support
- Add comprehensive accessibility attributes (ARIA labels, roles)
- Update labels, help text, and error messaging across all sections
- Add pill-shaped borders for specialized inputs
- Improve input-group, textarea, and input-otp components