### PR TITLE
Fix scroll lock not released after dismissing destructive action modal

### DIFF
--- a/src/components/wordpress/dataviews.tsx
+++ b/src/components/wordpress/dataviews.tsx
@@ -537,8 +537,15 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
 
         if (wasOpen && isClosed) {
             const timer = setTimeout(() => {
-                document.body.style.overflow = '';
-                document.documentElement.style.overflow = '';
+                const hasOpenOverlay =
+                    document.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
+                    document.documentElement.classList.contains('lockscroll') ||
+                    document.querySelector('[data-dialog-prevent-body-scroll]') !== null;
+
+                if (!hasOpenOverlay) {
+                    document.body.style.overflow = '';
+                    document.documentElement.style.overflow = '';
+                }
             }, 0);
             return () => clearTimeout(timer);
         }

--- a/src/components/wordpress/dataviews.tsx
+++ b/src/components/wordpress/dataviews.tsx
@@ -890,39 +890,37 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
             <Slot name={afterSlotId} fillProps={{ ...filteredProps }} />
 
             {/* Destructive action confirmation AlertDialog */}
-            {pendingDestructiveAction && (
-                <AlertDialog open onOpenChange={(open) => !open && !isConfirming && handleDestructiveCancel()}>
-                    <AlertDialogContent size="default">
-                        <AlertDialogHeader>
-                            <AlertDialogTitle>
-                                {pendingDestructiveAction.action.confirmTitle ||
-                                    (typeof pendingDestructiveAction.action.label === 'function'
-                                        ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
-                                        : pendingDestructiveAction.action.label)}
-                            </AlertDialogTitle>
-                            <AlertDialogDescription>
-                                {pendingDestructiveAction.action.confirmMessage ||
-                                    __('Are you sure? This action cannot be undone.', 'default')}
-                            </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                            <AlertDialogCancel onClick={handleDestructiveCancel} disabled={isConfirming}>
-                                {pendingDestructiveAction.action.cancelButtonLabel || __('Cancel', 'default')}
-                            </AlertDialogCancel>
-                            <AlertDialogAction
-                                variant="destructive"
-                                onClick={handleDestructiveConfirm}
-                                disabled={isConfirming}>
-                                {isConfirming && <Spinner className="mr-2" />}
-                                {pendingDestructiveAction.action.confirmButtonLabel ||
-                                    (typeof pendingDestructiveAction.action.label === 'function'
-                                        ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
-                                        : pendingDestructiveAction.action.label)}
-                            </AlertDialogAction>
-                        </AlertDialogFooter>
-                    </AlertDialogContent>
-                </AlertDialog>
-            )}
+            <AlertDialog open={!!pendingDestructiveAction} onOpenChange={(open) => !open && !isConfirming && handleDestructiveCancel()}>
+                <AlertDialogContent size="default">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            {pendingDestructiveAction?.action.confirmTitle ||
+                                (typeof pendingDestructiveAction?.action.label === 'function'
+                                    ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
+                                    : pendingDestructiveAction?.action.label)}
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {pendingDestructiveAction?.action.confirmMessage ||
+                                __('Are you sure? This action cannot be undone.', 'default')}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={handleDestructiveCancel} disabled={isConfirming}>
+                            {pendingDestructiveAction?.action.cancelButtonLabel || __('Cancel', 'default')}
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                            variant="destructive"
+                            onClick={handleDestructiveConfirm}
+                            disabled={isConfirming}>
+                            {isConfirming && <Spinner className="mr-2" />}
+                            {pendingDestructiveAction?.action.confirmButtonLabel ||
+                                (typeof pendingDestructiveAction?.action.label === 'function'
+                                    ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
+                                    : pendingDestructiveAction?.action.label)}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/src/components/wordpress/dataviews.tsx
+++ b/src/components/wordpress/dataviews.tsx
@@ -525,6 +525,25 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
     } | null>(null);
     const [isConfirming, setIsConfirming] = useState(false);
 
+    // Ariakit (WP Menu) and base-ui (AlertDialog) both manipulate body scroll
+    // styles independently. When one saves the other's overflow:hidden as the
+    // "original" state, closing the dialog restores that instead of the clean
+    // state. Force-clear after all their scheduled cleanups have run.
+    const prevPendingRef = useRef(pendingDestructiveAction);
+    useEffect(() => {
+        const wasOpen = prevPendingRef.current !== null;
+        const isClosed = pendingDestructiveAction === null;
+        prevPendingRef.current = pendingDestructiveAction;
+
+        if (wasOpen && isClosed) {
+            const timer = setTimeout(() => {
+                document.body.style.overflow = '';
+                document.documentElement.style.overflow = '';
+            }, 0);
+            return () => clearTimeout(timer);
+        }
+    }, [pendingDestructiveAction]);
+
     const handleDestructiveConfirm = useCallback(async () => {
         if (pendingDestructiveAction) {
             setIsConfirming(true);
@@ -890,37 +909,39 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
             <Slot name={afterSlotId} fillProps={{ ...filteredProps }} />
 
             {/* Destructive action confirmation AlertDialog */}
-            <AlertDialog open={!!pendingDestructiveAction} onOpenChange={(open) => !open && !isConfirming && handleDestructiveCancel()}>
-                <AlertDialogContent size="default">
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>
-                            {pendingDestructiveAction?.action.confirmTitle ||
-                                (typeof pendingDestructiveAction?.action.label === 'function'
-                                    ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
-                                    : pendingDestructiveAction?.action.label)}
-                        </AlertDialogTitle>
-                        <AlertDialogDescription>
-                            {pendingDestructiveAction?.action.confirmMessage ||
-                                __('Are you sure? This action cannot be undone.', 'default')}
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel onClick={handleDestructiveCancel} disabled={isConfirming}>
-                            {pendingDestructiveAction?.action.cancelButtonLabel || __('Cancel', 'default')}
-                        </AlertDialogCancel>
-                        <AlertDialogAction
-                            variant="destructive"
-                            onClick={handleDestructiveConfirm}
-                            disabled={isConfirming}>
-                            {isConfirming && <Spinner className="mr-2" />}
-                            {pendingDestructiveAction?.action.confirmButtonLabel ||
-                                (typeof pendingDestructiveAction?.action.label === 'function'
-                                    ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
-                                    : pendingDestructiveAction?.action.label)}
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            {pendingDestructiveAction && (
+                <AlertDialog open onOpenChange={(open) => !open && !isConfirming && handleDestructiveCancel()}>
+                    <AlertDialogContent size="default">
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>
+                                {pendingDestructiveAction.action.confirmTitle ||
+                                    (typeof pendingDestructiveAction.action.label === 'function'
+                                        ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
+                                        : pendingDestructiveAction.action.label)}
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                                {pendingDestructiveAction.action.confirmMessage ||
+                                    __('Are you sure? This action cannot be undone.', 'default')}
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel disabled={isConfirming}>
+                                {pendingDestructiveAction.action.cancelButtonLabel || __('Cancel', 'default')}
+                            </AlertDialogCancel>
+                            <AlertDialogAction
+                                variant="destructive"
+                                onClick={handleDestructiveConfirm}
+                                disabled={isConfirming}>
+                                {isConfirming && <Spinner className="mr-2" />}
+                                {pendingDestructiveAction.action.confirmButtonLabel ||
+                                    (typeof pendingDestructiveAction.action.label === 'function'
+                                        ? pendingDestructiveAction.action.label(pendingDestructiveAction.items)
+                                        : pendingDestructiveAction.action.label)}
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
+            )}
         </div>
     );
 }

--- a/src/components/wordpress/dataviews.tsx
+++ b/src/components/wordpress/dataviews.tsx
@@ -526,26 +526,15 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
     const [isConfirming, setIsConfirming] = useState(false);
 
     // Ariakit (WP Menu) and base-ui (AlertDialog) both manipulate body scroll
-    // styles independently. When one saves the other's overflow:hidden as the
-    // "original" state, closing the dialog restores that instead of the clean
-    // state. Force-clear after all their scheduled cleanups have run.
-    const prevPendingRef = useRef(pendingDestructiveAction);
+    // styles independently. Force hidden when open, clear when closed.
     useEffect(() => {
-        const wasOpen = prevPendingRef.current !== null;
-        const isClosed = pendingDestructiveAction === null;
-        prevPendingRef.current = pendingDestructiveAction;
-
-        if (wasOpen && isClosed) {
+        if (pendingDestructiveAction) {
+            document.body.style.overflow = 'hidden';
+            document.documentElement.style.overflow = 'hidden';
+        } else {
             const timer = setTimeout(() => {
-                const hasOpenOverlay =
-                    document.documentElement.hasAttribute('data-base-ui-scroll-locked') ||
-                    document.documentElement.classList.contains('lockscroll') ||
-                    document.querySelector('[data-dialog-prevent-body-scroll]') !== null;
-
-                if (!hasOpenOverlay) {
-                    document.body.style.overflow = '';
-                    document.documentElement.style.overflow = '';
-                }
+                document.body.style.overflow = '';
+                document.documentElement.style.overflow = '';
             }, 0);
             return () => clearTimeout(timer);
         }
@@ -623,11 +612,14 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
 
     const tabViewKey = tabs?.viewKey ?? 'status';
 
-    const handleViewChange = useCallback((nextView: View) => {
-        // Sync key pieces of state into the URL so that the UI is shareable and bookmarkable.
-        updateUrlQueryParams(getQueryParamsFromView(nextView, tabViewKey));
-        onChangeView(nextView);
-    }, [tabViewKey, onChangeView]);
+    const handleViewChange = useCallback(
+        (nextView: View) => {
+            // Sync key pieces of state into the URL so that the UI is shareable and bookmarkable.
+            updateUrlQueryParams(getQueryParamsFromView(nextView, tabViewKey));
+            onChangeView(nextView);
+        },
+        [tabViewKey, onChangeView]
+    );
 
     const baseProps = {
         ...dataViewsTableProps,
@@ -896,7 +888,9 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
                                 className={cn(
                                     'animate-in py-1.5 fade-in-0 slide-in-from-top-1 duration-200 transition-all ease-in-out flex items-center bg-background z-1 border-b px-5 min-h-13 justify-between border-border rounded-t-md w-full'
                                 )}
-                                style={theadHeight ? { marginBottom: -theadHeight, minHeight: theadHeight } : undefined}>
+                                style={
+                                    theadHeight ? { marginBottom: -theadHeight, minHeight: theadHeight } : undefined
+                                }>
                                 <DataViewsTable.BulkActionToolbar />
                             </div>
                         )}
@@ -928,7 +922,7 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
             {/* Destructive action confirmation AlertDialog */}
             {pendingDestructiveAction && (
                 <AlertDialog open onOpenChange={(open) => !open && !isConfirming && handleDestructiveCancel()}>
-                    <AlertDialogContent size="default">
+                    <AlertDialogContent className="pui-dataview-alert-dialog" size="default">
                         <AlertDialogHeader>
                             <AlertDialogTitle>
                                 {pendingDestructiveAction.action.confirmTitle ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable page scrolling after destructive confirmation dialogs close to prevent stuck/no-scroll states.
  * Cancel action refined so it doesn’t interrupt an ongoing destructive confirmation; cancellation now applies only when the dialog actually closes.
  * Cleanup timing improved to avoid residual scroll locks or overlays after dialog dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->