### PR TITLE
feat: add WpMediaUpload field type for WordPress Media Library

### DIFF
--- a/.claude/commands/settings-integration.md
+++ b/.claude/commands/settings-integration.md
@@ -1,0 +1,365 @@
+---
+name: "Settings Integration"
+description: Guide for integrating plugin-ui <Settings> into a WordPress plugin — covers PHP schema, REST API, frontend wiring, CSS, testing, and common pitfalls.
+category: Integration
+tags: [settings, plugin-ui, wordpress, php, rest-api, react]
+---
+
+You are helping a developer integrate the `@wedevs/plugin-ui` `<Settings>` component into a WordPress plugin.
+
+When invoked with `/settings-integration`, read the current codebase to understand the integration state, then guide, scaffold, or fix whatever the user asks.
+
+---
+
+## Architecture Overview
+
+The integration has two layers that must stay in sync:
+
+```
+PHP (Backend)                        React (Frontend)
+─────────────────────────────────    ────────────────────────────────────
+AbstractSettingsSchema               useSettings hook
+  └─ get_schema() → flat array  ──►  schema[] → plugin-ui <Settings>
+  └─ save(data)                 ◄──  onSave(treeValues)
+  └─ get_option_key()                useSettingsPage hook (query params)
+
+WP_REST_Controller
+  └─ GET  /settings/schema      ──►  schemaEndpoint
+  └─ GET  /settings             ──►  (values merged into schema)
+  └─ POST /settings             ◄──  saveEndpoint
+```
+
+---
+
+## PHP Backend
+
+### 1. AbstractSettingsSchema
+
+Every integration extends this abstract class. The key contract:
+
+```php
+abstract class AbstractSettingsSchema implements SettingsSchemaInterface {
+    abstract protected function slug(): string; // e.g. 'woocommerce', 'dokan'
+
+    // Override to add integration-specific pages/sections/fields
+    protected function pages(): array   { return []; }
+    protected function sections(): array { return []; }
+    protected function fields(array $settings): array { return []; }
+
+    // Override to add integration-specific sanitization
+    protected function sanitize(array $data): array {
+        return $this->sanitize_common($data); // always call parent
+    }
+}
+```
+
+**Option key** is automatically `pocket_store_{slug}_settings`.
+
+### 2. Field Definition Structure
+
+```php
+[
+    'id'             => 'tag_line',           // CRITICAL: must match WP REST args key for nested objects
+    'type'           => 'field',
+    'variant'        => 'text',               // text | show_hide | color_picker | switch | wp_media_upload
+    'label'          => __('Tag Line', 'my-plugin'),
+    'section_id'     => 'app_identity',       // groups this field under its section
+    'value'          => $settings['tag_line'] ?? '',
+    'description'    => __('App tagline text.', 'my-plugin'),
+]
+```
+
+**Available variants:**
+| Variant | Use for |
+|---|---|
+| `text` | Plain text input |
+| `show_hide` | Secrets/passwords — eye toggle button |
+| `color_picker` | Hex color values |
+| `switch` | Boolean toggle |
+| `wp_media_upload` | Image/media URLs |
+| `number` | Numeric values |
+| `select` | Dropdown |
+
+**Never use `'password'` variant** — use `'show_hide'` instead.
+
+### 3. Section-Grouped Payload (Critical)
+
+plugin-ui's `enrichNode()` **always overwrites** any PHP-set `dependency_key` with:
+```
+child.dependency_key = parent.dependency_key + '.' + child.id
+```
+
+So a field `id='tag_line'` under section `id='app_identity'` gets `dependency_key='app_identity.tag_line'`.
+
+`handleOnSave` splits on `.` to build `treeValues`:
+```json
+{ "app_identity": { "tag_line": "My App", "app_logo": "https://..." } }
+```
+
+**PHP `sanitize()` must read section-grouped data:**
+```php
+protected function sanitize(array $data): array {
+    $result = $this->sanitize_common($data); // handles common sections
+
+    if (isset($data['vendor_app'])) {
+        $s = $data['vendor_app'];
+        $result['enable_vendor_app'] = (bool)($s['enable_vendor_app'] ?? true);
+        $result['vendor_tagline']    = sanitize_text_field($s['vendor_tagline'] ?? '');
+    }
+    return $result;
+}
+```
+
+### 4. Nested Object Fields and WP REST Args
+
+For nested objects (e.g. `onesignal`), field **IDs must match the WP REST args property names**:
+
+```php
+// CORRECT — field id matches REST args property key
+[ 'id' => 'app_id',      'section_id' => 'onesignal', ... ]
+[ 'id' => 'rest_api_key','section_id' => 'onesignal', ... ]
+
+// WRONG — WP REST strips 'onesignal_app_id' (not in registered properties)
+[ 'id' => 'onesignal_app_id', 'section_id' => 'onesignal', ... ]
+```
+
+WP REST **strips unknown properties** from registered `object` args. If stripped, the object becomes `{}` and `required: true` properties fail validation.
+
+**Set `'required' => false` on nested properties** to allow partial saves:
+```php
+'onesignal' => [
+    'required'   => false,
+    'type'       => 'object',
+    'properties' => [
+        'app_id'       => [ 'required' => false, 'type' => 'string', 'default' => '' ],
+        'rest_api_key' => [ 'required' => false, 'type' => 'string', 'default' => '' ],
+    ],
+],
+```
+
+### 5. Partial Save / Merge Pattern
+
+`save()` must **merge** with existing data, not overwrite:
+```php
+public function save(array $data): void {
+    $existing  = get_option($this->get_option_key(), []);
+    $sanitized = $this->sanitize($data);
+    update_option($this->get_option_key(), array_merge($existing, $sanitized), false);
+}
+```
+
+The frontend only sends the current page's sections on save. `array_merge` ensures other sections are preserved.
+
+### 6. sanitize_hex_color Gotcha
+
+`sanitize_hex_color()` returns `null` for invalid hex strings. Never use placeholder values like `'#NEWCOLOR'` — use real hex values like `'#FF9472'`.
+
+---
+
+## Frontend
+
+### 1. App Structure
+
+```tsx
+import { ThemeProvider, Settings, Toaster } from '@wedevs/plugin-ui';
+import { useSettings, useSettingsPage } from '../../hooks';
+
+const MyApp = () => {
+    const { schema, values, isLoading, onChange, onSave } = useSettings(
+        'my-plugin/v1/settings/schema',
+        'my-plugin/v1/settings'
+    );
+    const { initialPage, onNavigate } = useSettingsPage();
+
+    if (isLoading) return <div className="p-6"><p>Loading...</p></div>;
+
+    return (
+        <ThemeProvider pluginId="my-plugin" tokens={{ primary: '#6366f1', primaryForeground: '#ffffff' }}>
+            <div className="pui-root">
+                <Settings
+                    title={__('My Plugin Settings', 'my-plugin')}
+                    schema={schema}
+                    values={values}
+                    onChange={onChange}
+                    onSave={onSave}
+                    initialPage={initialPage}
+                    onNavigate={onNavigate}
+                />
+                <Toaster richColors />
+            </div>
+        </ThemeProvider>
+    );
+};
+```
+
+### 2. useSettings Hook
+
+```ts
+const onSave = useCallback(
+    async (_scopeId: string, treeValues: Record<string, any>) => {
+        try {
+            await apiFetch({ path: saveEndpoint, method: 'POST', data: treeValues });
+            await fetchSchema(); // refresh values from server
+            toast.success(__('Settings saved.', 'my-plugin'));
+        } catch (err: any) {
+            toast.error(err?.message ?? __('Failed to save settings.', 'my-plugin'));
+        }
+    },
+    [saveEndpoint, fetchSchema]
+);
+```
+
+**Always `fetchSchema()` after save** — the server is the source of truth for sanitized values.
+
+### 3. useSettingsPage Hook (Query Param Persistence)
+
+```ts
+const PARAM = 'settings_page';
+
+export function useSettingsPage() {
+    const initialPage = new URLSearchParams(window.location.search).get(PARAM) ?? undefined;
+
+    const onNavigate = useCallback((pageId: string) => {
+        const url = new URL(window.location.href);
+        url.searchParams.set(PARAM, pageId);
+        window.history.replaceState(null, '', url.toString());
+    }, []);
+
+    return { initialPage, onNavigate };
+}
+```
+
+URL becomes: `admin.php?page=mobile-app-vendor-app&settings_page=appearance`
+
+The `initialPage` prop on `<Settings>` seeds the active page from the URL on mount. `onNavigate` updates the URL without a page reload when the user switches pages.
+
+---
+
+## CSS — WordPress Admin Conflicts
+
+### 1. Root Scoping
+
+All app output must be wrapped in `<div className="pui-root">`. All CSS resets and conflict fixes are scoped to `.pui-root`.
+
+### 2. WordPress Admin Heading/Paragraph Overrides
+
+WP admin sets `h2, h3 { color: #1d2327; font-size: 1.3em }` and paragraph margins. Reset inside `index.css`:
+
+```css
+.pui-root h1, .pui-root h2, .pui-root h3,
+.pui-root h4, .pui-root h5, .pui-root h6 {
+    color: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    margin: 0;
+}
+
+.pui-root p {
+    color: inherit !important;
+    font-size: inherit !important;
+    margin: 0;
+}
+```
+
+### 3. Tailwind v3/v4 Transform Conflict
+
+Other WP plugins (e.g. Dokan Pro) may use Tailwind v3 which generates:
+```css
+.-translate-y-1\/2 { transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(...); }
+```
+
+plugin-ui uses Tailwind v4's individual `translate` CSS property. Both apply simultaneously causing double-translation. Fix in `index.css`:
+
+```css
+/* Reset Tailwind v3 transform shorthand from other plugins */
+.pui-root [class*="translate-"],
+.pui-root [class*="-translate-"] {
+    transform: none !important;
+}
+```
+
+This is safe — Tailwind v4 uses `translate` (not `transform`) for positioning.
+
+---
+
+## PHP Unit Testing
+
+Use `WP_Test_REST_TestCase` to test the REST endpoints:
+
+```php
+class SettingsApiTest extends WP_Test_REST_TestCase {
+    protected $server;
+    protected $admin_id;
+
+    public function set_up(): void {
+        parent::set_up();
+        global $wp_rest_server;
+        $this->server = $wp_rest_server = new WP_REST_Server();
+        do_action('rest_api_init');
+        $this->admin_id = $this->factory->user->create(['role' => 'administrator']);
+        wp_set_current_user($this->admin_id);
+        delete_option('my_plugin_settings');
+    }
+
+    private function post_request(string $path, array $body): array {
+        $request = new WP_REST_Request('POST', $path);
+        $request->set_header('Content-Type', 'application/json');
+        $request->set_body(wp_json_encode($body));
+        $response = $this->server->dispatch($request);
+        $this->assertNotWPError($response);
+        return $response->get_data();
+    }
+}
+```
+
+**Test the section-grouped payload** — not flat keys:
+```php
+// CORRECT
+$this->post_request('/my-plugin/v1/settings', [
+    'app_identity' => ['tag_line' => 'My App', 'app_logo' => ''],
+]);
+
+// WRONG — this is what the old flat format looked like
+$this->post_request('/my-plugin/v1/settings', ['tag_line' => 'My App']);
+```
+
+**Test partial save preserves other sections:**
+```php
+// Call schema->save() directly to bypass WP REST arg defaults injection
+$schema->save(['app_identity' => ['tag_line' => 'Original', ...]]);
+$schema->save(['button_colors' => ['primary_button_color_1' => '#111111', ...]]);
+
+$saved = get_option('my_option_key');
+$this->assertSame('Original', $saved['tag_line']); // preserved
+$this->assertSame('#111111', $saved['primary_button_color_1']); // updated
+```
+
+---
+
+## Common Pitfalls Checklist
+
+| Pitfall | Fix |
+|---|---|
+| Using `'password'` variant | Use `'show_hide'` |
+| Field IDs don't match WP REST args properties | Align IDs — WP REST strips unknown properties |
+| WP REST arg properties have `required: true` | Set `required: false` to allow partial saves |
+| `save()` overwrites the entire option | Use `array_merge($existing, $sanitized)` |
+| `sanitize_hex_color()` returns null | Only pass valid hex strings; test colors like `#FF9472` not `#NEWCOLOR` |
+| Double-translation from Tailwind v3 conflict | Add `transform: none !important` reset inside `.pui-root` |
+| WP admin h2/h3/p styles leaking in | Reset `color`, `font-size`, `margin` inside `.pui-root` |
+| Active page lost on reload | Use `useSettingsPage` hook with `initialPage` + `onNavigate` |
+| Toast not appearing | Add `<Toaster richColors />` inside `<div className="pui-root">` |
+| `fetchSchema()` not called after save | Always call it — server sanitizes values |
+
+---
+
+## Steps for a New Integration
+
+1. **PHP**: Create `{Integration}SettingsSchema extends AbstractSettingsSchema` — implement `slug()`, `sections()`, `fields()`, `sanitize()`
+2. **PHP**: Create `{Integration}SettingsController extends WP_REST_Controller` — register `GET /settings/schema`, `GET /settings`, `POST /settings`
+3. **PHP**: Register the controller in your `ServiceProvider` / `Integration` class
+4. **Frontend**: Create an app component with `ThemeProvider + pui-root + Settings + Toaster`
+5. **Frontend**: Use `useSettings(schemaEndpoint, saveEndpoint)` hook
+6. **Frontend**: Use `useSettingsPage()` and pass `initialPage` + `onNavigate` to `<Settings>`
+7. **CSS**: Add `pui-root` heading/paragraph resets and transform conflict fix to `index.css`
+8. **Tests**: Write `WP_Test_REST_TestCase` tests covering schema, fetch, save each section, partial save, sanitization, auth guard

--- a/.claude/commands/settings-integration.md
+++ b/.claude/commands/settings-integration.md
@@ -272,8 +272,6 @@ const MyApp = () => {
     );
     const { initialPage, onNavigate } = useSettingsPage();
 
-    if (isLoading) return <div className="p-6"><p>{__('Loading...', 'my-plugin')}</p></div>;
-
     return (
         <ThemeProvider pluginId="my-plugin" tokens={{ primary: '#6366f1', primaryForeground: '#ffffff' }}>
             <div className="pui-root your-plugin-root">
@@ -281,6 +279,7 @@ const MyApp = () => {
                     title={__('My Plugin Settings', 'my-plugin')}
                     schema={schema}
                     values={values}
+                    loading={isLoading}
                     onChange={onChange}
                     onSave={onSave}
                     initialPage={initialPage}
@@ -292,6 +291,8 @@ const MyApp = () => {
     );
 };
 ```
+
+Pass `loading={isLoading}` directly to `<Settings>` — it renders a `<SettingsSkeleton>` automatically while data loads. No manual loading guard needed.
 
 ### 2. useSettings Hook
 

--- a/.claude/commands/settings-integration.md
+++ b/.claude/commands/settings-integration.md
@@ -11,6 +11,104 @@ When invoked with `/settings-integration`, read the current codebase to understa
 
 ---
 
+## First-Time Setup
+
+### 1. Install the package
+
+plugin-ui is a **private weDevs package** — not on npm. Choose based on your intent:
+
+**Using plugin-ui (consumer — no changes needed):**
+
+```bash
+# Install directly from GitHub
+pnpm add github:getdokan/plugin-ui
+```
+
+Or pin a specific tag/branch:
+
+```bash
+pnpm add github:getdokan/plugin-ui#main
+pnpm add github:getdokan/plugin-ui#v2.0.0
+```
+
+**Contributing to plugin-ui (local development):**
+
+Clone plugin-ui alongside your plugin, then reference it by local path:
+
+```json
+// package.json
+"dependencies": {
+    "@wedevs/plugin-ui": "file:../plugin-ui"
+}
+```
+
+```bash
+pnpm install
+```
+
+With the local path approach, changes you make in `../plugin-ui/src` are picked up after rebuilding plugin-ui (`pnpm run build` inside plugin-ui). If TypeScript types drift after a rebuild, force-copy the updated dist:
+
+```bash
+cp -r ../plugin-ui/dist/* node_modules/@wedevs/plugin-ui/dist/
+```
+
+### 2. Peer dependencies
+
+```bash
+pnpm add react react-dom @wordpress/i18n @wordpress/api-fetch @wordpress/hooks
+pnpm add -D @types/react @types/react-dom
+```
+
+### 3. Enqueue in PHP
+
+```php
+wp_enqueue_script(
+    'my-plugin-admin',
+    plugin_dir_url(__FILE__) . 'assets/js/main.js',
+    [ 'wp-element', 'wp-i18n', 'wp-api-fetch', 'wp-hooks' ],
+    MY_PLUGIN_VERSION,
+    true
+);
+wp_enqueue_style(
+    'my-plugin-admin',
+    plugin_dir_url(__FILE__) . 'assets/css/main.css',
+    [],
+    MY_PLUGIN_VERSION
+);
+// Provide REST nonce for apiFetch
+wp_add_inline_script(
+    'my-plugin-admin',
+    sprintf(
+        'wp.apiFetch.use( wp.apiFetch.createNonceMiddleware( "%s" ) );',
+        wp_create_nonce( 'wp_rest' )
+    ),
+    'after'
+);
+```
+
+### 4. Mount point in PHP template
+
+```php
+// In your admin page callback
+echo '<div id="my-plugin-settings"></div>';
+```
+
+### 5. React entry point
+
+```tsx
+// src/index.tsx
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import MyApp from './apps/my-plugin';
+
+const mountPoint = document.getElementById('my-plugin-settings');
+if (mountPoint) {
+    createRoot(mountPoint).render(<MyApp />);
+}
+```
+
+---
+
 ## Architecture Overview
 
 The integration has two layers that must stay in sync:
@@ -39,7 +137,7 @@ Every integration extends this abstract class. The key contract:
 
 ```php
 abstract class AbstractSettingsSchema implements SettingsSchemaInterface {
-    abstract protected function slug(): string; // e.g. 'woocommerce', 'dokan'
+    abstract protected function slug(): string; // e.g. 'my-integration'
 
     // Override to add integration-specific pages/sections/fields
     protected function pages(): array   { return []; }
@@ -53,7 +151,7 @@ abstract class AbstractSettingsSchema implements SettingsSchemaInterface {
 }
 ```
 
-**Option key** is automatically `pocket_store_{slug}_settings`.
+**Option key** is derived from `slug()` — check your base class implementation for the exact pattern (e.g. `my_plugin_{slug}_settings`).
 
 ### 2. Field Definition Structure
 
@@ -61,7 +159,7 @@ abstract class AbstractSettingsSchema implements SettingsSchemaInterface {
 [
     'id'             => 'tag_line',           // CRITICAL: must match WP REST args key for nested objects
     'type'           => 'field',
-    'variant'        => 'text',               // text | show_hide | color_picker | switch | wp_media_upload
+    'variant'        => 'text',               // see variant table below
     'label'          => __('Tag Line', 'my-plugin'),
     'section_id'     => 'app_identity',       // groups this field under its section
     'value'          => $settings['tag_line'] ?? '',
@@ -79,6 +177,8 @@ abstract class AbstractSettingsSchema implements SettingsSchemaInterface {
 | `wp_media_upload` | Image/media URLs |
 | `number` | Numeric values |
 | `select` | Dropdown |
+| `textarea` | Multi-line text |
+| `rich_text` | WYSIWYG editor |
 
 **Never use `'password'` variant** — use `'show_hide'` instead.
 
@@ -101,10 +201,10 @@ So a field `id='tag_line'` under section `id='app_identity'` gets `dependency_ke
 protected function sanitize(array $data): array {
     $result = $this->sanitize_common($data); // handles common sections
 
-    if (isset($data['vendor_app'])) {
-        $s = $data['vendor_app'];
-        $result['enable_vendor_app'] = (bool)($s['enable_vendor_app'] ?? true);
-        $result['vendor_tagline']    = sanitize_text_field($s['vendor_tagline'] ?? '');
+    if (isset($data['app_identity'])) {
+        $s = $data['app_identity'];
+        $result['tag_line'] = sanitize_text_field($s['tag_line'] ?? '');
+        $result['app_logo'] = esc_url_raw($s['app_logo'] ?? '');
     }
     return $result;
 }
@@ -112,27 +212,27 @@ protected function sanitize(array $data): array {
 
 ### 4. Nested Object Fields and WP REST Args
 
-For nested objects (e.g. `onesignal`), field **IDs must match the WP REST args property names**:
+For nested objects, field **IDs must match the WP REST args property names**:
 
 ```php
 // CORRECT — field id matches REST args property key
-[ 'id' => 'app_id',      'section_id' => 'onesignal', ... ]
-[ 'id' => 'rest_api_key','section_id' => 'onesignal', ... ]
+[ 'id' => 'app_id',      'section_id' => 'push_notifications', ... ]
+[ 'id' => 'api_key',     'section_id' => 'push_notifications', ... ]
 
-// WRONG — WP REST strips 'onesignal_app_id' (not in registered properties)
-[ 'id' => 'onesignal_app_id', 'section_id' => 'onesignal', ... ]
+// WRONG — WP REST strips 'push_app_id' (not in registered properties)
+[ 'id' => 'push_app_id', 'section_id' => 'push_notifications', ... ]
 ```
 
 WP REST **strips unknown properties** from registered `object` args. If stripped, the object becomes `{}` and `required: true` properties fail validation.
 
 **Set `'required' => false` on nested properties** to allow partial saves:
 ```php
-'onesignal' => [
+'push_notifications' => [
     'required'   => false,
     'type'       => 'object',
     'properties' => [
-        'app_id'       => [ 'required' => false, 'type' => 'string', 'default' => '' ],
-        'rest_api_key' => [ 'required' => false, 'type' => 'string', 'default' => '' ],
+        'app_id'  => [ 'required' => false, 'type' => 'string', 'default' => '' ],
+        'api_key' => [ 'required' => false, 'type' => 'string', 'default' => '' ],
     ],
 ],
 ```
@@ -152,7 +252,7 @@ The frontend only sends the current page's sections on save. `array_merge` ensur
 
 ### 6. sanitize_hex_color Gotcha
 
-`sanitize_hex_color()` returns `null` for invalid hex strings. Never use placeholder values like `'#NEWCOLOR'` — use real hex values like `'#FF9472'`.
+`sanitize_hex_color()` returns `null` for invalid hex strings. Always use real hex values in defaults and tests (e.g. `'#FF9472'`, not placeholder strings like `'#MYCOLOR'`).
 
 ---
 
@@ -162,6 +262,7 @@ The frontend only sends the current page's sections on save. `array_merge` ensur
 
 ```tsx
 import { ThemeProvider, Settings, Toaster } from '@wedevs/plugin-ui';
+import { __ } from '@wordpress/i18n';
 import { useSettings, useSettingsPage } from '../../hooks';
 
 const MyApp = () => {
@@ -171,11 +272,11 @@ const MyApp = () => {
     );
     const { initialPage, onNavigate } = useSettingsPage();
 
-    if (isLoading) return <div className="p-6"><p>Loading...</p></div>;
+    if (isLoading) return <div className="p-6"><p>{__('Loading...', 'my-plugin')}</p></div>;
 
     return (
         <ThemeProvider pluginId="my-plugin" tokens={{ primary: '#6366f1', primaryForeground: '#ffffff' }}>
-            <div className="pui-root">
+            <div className="pui-root your-plugin-root">
                 <Settings
                     title={__('My Plugin Settings', 'my-plugin')}
                     schema={schema}
@@ -194,26 +295,56 @@ const MyApp = () => {
 
 ### 2. useSettings Hook
 
+Implement in `src/hooks/useSettings.ts`:
+
 ```ts
-const onSave = useCallback(
-    async (_scopeId: string, treeValues: Record<string, any>) => {
-        try {
-            await apiFetch({ path: saveEndpoint, method: 'POST', data: treeValues });
-            await fetchSchema(); // refresh values from server
-            toast.success(__('Settings saved.', 'my-plugin'));
-        } catch (err: any) {
-            toast.error(err?.message ?? __('Failed to save settings.', 'my-plugin'));
-        }
-    },
-    [saveEndpoint, fetchSchema]
-);
+import { useState, useCallback } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { toast } from '@wedevs/plugin-ui';
+import { __ } from '@wordpress/i18n';
+
+export function useSettings(schemaEndpoint: string, saveEndpoint: string) {
+    const [schema, setSchema] = useState([]);
+    const [values, setValues] = useState({});
+    const [isLoading, setIsLoading] = useState(true);
+
+    const fetchSchema = useCallback(async () => {
+        const data = await apiFetch({ path: schemaEndpoint });
+        setSchema(data.schema);
+        setValues(data.values);
+        setIsLoading(false);
+    }, [schemaEndpoint]);
+
+    const onChange = useCallback((key: string, value: any) => {
+        setValues((prev) => ({ ...prev, [key]: value }));
+    }, []);
+
+    const onSave = useCallback(
+        async (_scopeId: string, treeValues: Record<string, any>) => {
+            try {
+                await apiFetch({ path: saveEndpoint, method: 'POST', data: treeValues });
+                await fetchSchema(); // always refresh — server is source of truth
+                toast.success(__('Settings saved.', 'my-plugin'));
+            } catch (err: any) {
+                toast.error(err?.message ?? __('Failed to save settings.', 'my-plugin'));
+            }
+        },
+        [saveEndpoint, fetchSchema]
+    );
+
+    return { schema, values, isLoading, onChange, onSave };
+}
 ```
 
-**Always `fetchSchema()` after save** — the server is the source of truth for sanitized values.
+**Always `fetchSchema()` after save** — the server sanitizes values (e.g. strips invalid hex) and the UI must reflect the canonical saved state.
 
 ### 3. useSettingsPage Hook (Query Param Persistence)
 
+Implement in `src/hooks/useSettingsPage.ts`:
+
 ```ts
+import { useCallback } from 'react';
+
 const PARAM = 'settings_page';
 
 export function useSettingsPage() {
@@ -229,7 +360,7 @@ export function useSettingsPage() {
 }
 ```
 
-URL becomes: `admin.php?page=mobile-app-vendor-app&settings_page=appearance`
+URL becomes: `admin.php?page=my-plugin-settings&settings_page=appearance`
 
 The `initialPage` prop on `<Settings>` seeds the active page from the URL on mount. `onNavigate` updates the URL without a page reload when the user switches pages.
 
@@ -239,11 +370,56 @@ The `initialPage` prop on `<Settings>` seeds the active page from the URL on mou
 
 ### 1. Root Scoping
 
-All app output must be wrapped in `<div className="pui-root">`. All CSS resets and conflict fixes are scoped to `.pui-root`.
+All app output must be wrapped in `<div className="pui-root your-plugin-root">`. All CSS resets must be scoped to these selectors to avoid leaking into WP admin.
 
-### 2. WordPress Admin Heading/Paragraph Overrides
+### 2. Scoped Tailwind Preflight + Utilities (Critical)
 
-WP admin sets `h2, h3 { color: #1d2327; font-size: 1.3em }` and paragraph margins. Reset inside `index.css`:
+WordPress admin loads its own global styles. Tailwind's default preflight resets affect everything on the page if applied globally. **Scope both preflight and utilities inside your root selector** so they only apply within your plugin's UI:
+
+```css
+/* src/index.css */
+@import "tailwindcss";
+@source "./";  /* or path to your src dir */
+@import "@wedevs/plugin-ui/dist/index.css";
+
+/* Replace with your plugin's actual mount-point selectors */
+.pui-root,
+.your-plugin-root {
+    @import 'tailwindcss/preflight.css' layer(base) important;
+    @import 'tailwindcss/utilities.css' layer(utilities) important;
+
+    @layer base {
+        *,
+        ::after,
+        ::before,
+        ::backdrop,
+        ::file-selector-button {
+            border-color: var(--color-gray-200, currentColor);
+        }
+
+        &.dark *,
+        &.dark ::after,
+        &.dark ::before,
+        &.dark ::backdrop,
+        &.dark ::file-selector-button {
+            border-color: var(--color-gray-600, currentColor);
+        }
+
+        button:not(:disabled),
+        [role='button']:not(:disabled) {
+            @apply cursor-pointer;
+        }
+    }
+}
+```
+
+**Why scoping matters:** Without it, Tailwind preflight zeroes out all WP admin styles globally — breaking the admin menu, notices, and other plugins. With scoping, resets only apply inside your mount point.
+
+**The root selectors** are the `class` attributes on your React mount divs. Always include `.pui-root` (plugin-ui's own wrapper class) plus any top-level class your plugin adds.
+
+### 3. WordPress Admin Heading/Paragraph Overrides
+
+WP admin's stylesheet sets `h2, h3 { color: #1d2327; font-size: 1.3em }` and paragraph margins. These leak into your UI even with scoped preflight because they come from WP admin's own CSS, not Tailwind. Reset them explicitly:
 
 ```css
 .pui-root h1, .pui-root h2, .pui-root h3,
@@ -261,14 +437,14 @@ WP admin sets `h2, h3 { color: #1d2327; font-size: 1.3em }` and paragraph margin
 }
 ```
 
-### 3. Tailwind v3/v4 Transform Conflict
+### 4. Tailwind v3/v4 Transform Conflict
 
-Other WP plugins (e.g. Dokan Pro) may use Tailwind v3 which generates:
+Other WP plugins may use Tailwind v3 which generates:
 ```css
 .-translate-y-1\/2 { transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(...); }
 ```
 
-plugin-ui uses Tailwind v4's individual `translate` CSS property. Both apply simultaneously causing double-translation. Fix in `index.css`:
+plugin-ui uses Tailwind v4's individual `translate` CSS property. Both apply simultaneously causing double-translation. Fix:
 
 ```css
 /* Reset Tailwind v3 transform shorthand from other plugins */
@@ -279,6 +455,59 @@ plugin-ui uses Tailwind v4's individual `translate` CSS property. Both apply sim
 ```
 
 This is safe — Tailwind v4 uses `translate` (not `transform`) for positioning.
+
+---
+
+## Extending Fields via Filter Hooks
+
+Every field variant is wrapped with `applyFilters(hookName, <DefaultComponent />, element)`.
+
+**Hook name pattern:** `${hookPrefix}_settings_${variant}_field`
+
+Default `hookPrefix` is `'plugin_ui'`. Override via `<Settings hookPrefix="my_plugin" />`.
+
+### Override an existing variant
+
+```tsx
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+    'my_plugin_settings_text_field',
+    'my-plugin/custom-text',
+    (DefaultComponent, element) => {
+        if (element.id === 'special_field') {
+            return <MySpecialField element={element} />;
+        }
+        return DefaultComponent;
+    }
+);
+```
+
+### Register a completely new variant
+
+In PHP schema: `'variant' => 'date_picker'`. Unknown variants hit the `default` switch case and fire `${hookPrefix}_settings_date_picker_field` with `<FallbackField />` as the default:
+
+```tsx
+addFilter(
+    'my_plugin_settings_date_picker_field',
+    'my-plugin/date-picker',
+    (_Fallback, element) => <MyDatePicker element={element} />
+);
+```
+
+### Wire applyFilters to `<Settings>`
+
+The `applyFilters` prop must receive the actual `@wordpress/hooks` function — otherwise filters are no-ops:
+
+```tsx
+import { applyFilters } from '@wordpress/hooks';
+
+<Settings
+    applyFilters={applyFilters}
+    hookPrefix="my_plugin"
+    // ...
+/>
+```
 
 ---
 
@@ -319,19 +548,19 @@ $this->post_request('/my-plugin/v1/settings', [
     'app_identity' => ['tag_line' => 'My App', 'app_logo' => ''],
 ]);
 
-// WRONG — this is what the old flat format looked like
+// WRONG — old flat format, will not be read by sanitize()
 $this->post_request('/my-plugin/v1/settings', ['tag_line' => 'My App']);
 ```
 
 **Test partial save preserves other sections:**
 ```php
 // Call schema->save() directly to bypass WP REST arg defaults injection
-$schema->save(['app_identity' => ['tag_line' => 'Original', ...]]);
-$schema->save(['button_colors' => ['primary_button_color_1' => '#111111', ...]]);
+$schema->save(['app_identity' => ['tag_line' => 'Original', 'app_logo' => '']]);
+$schema->save(['appearance'   => ['primary_color' => '#111111']]);
 
 $saved = get_option('my_option_key');
 $this->assertSame('Original', $saved['tag_line']); // preserved
-$this->assertSame('#111111', $saved['primary_button_color_1']); // updated
+$this->assertSame('#111111', $saved['primary_color']); // updated
 ```
 
 ---
@@ -344,12 +573,14 @@ $this->assertSame('#111111', $saved['primary_button_color_1']); // updated
 | Field IDs don't match WP REST args properties | Align IDs — WP REST strips unknown properties |
 | WP REST arg properties have `required: true` | Set `required: false` to allow partial saves |
 | `save()` overwrites the entire option | Use `array_merge($existing, $sanitized)` |
-| `sanitize_hex_color()` returns null | Only pass valid hex strings; test colors like `#FF9472` not `#NEWCOLOR` |
+| `sanitize_hex_color()` returns null | Only pass valid hex strings; never use placeholder values |
+| Tailwind preflight applied globally | Scope `preflight.css` + `utilities.css` inside root selector |
 | Double-translation from Tailwind v3 conflict | Add `transform: none !important` reset inside `.pui-root` |
 | WP admin h2/h3/p styles leaking in | Reset `color`, `font-size`, `margin` inside `.pui-root` |
 | Active page lost on reload | Use `useSettingsPage` hook with `initialPage` + `onNavigate` |
 | Toast not appearing | Add `<Toaster richColors />` inside `<div className="pui-root">` |
 | `fetchSchema()` not called after save | Always call it — server sanitizes values |
+| Filters not running | Pass `applyFilters` from `@wordpress/hooks` to `<Settings>` |
 
 ---
 
@@ -359,7 +590,7 @@ $this->assertSame('#111111', $saved['primary_button_color_1']); // updated
 2. **PHP**: Create `{Integration}SettingsController extends WP_REST_Controller` — register `GET /settings/schema`, `GET /settings`, `POST /settings`
 3. **PHP**: Register the controller in your `ServiceProvider` / `Integration` class
 4. **Frontend**: Create an app component with `ThemeProvider + pui-root + Settings + Toaster`
-5. **Frontend**: Use `useSettings(schemaEndpoint, saveEndpoint)` hook
-6. **Frontend**: Use `useSettingsPage()` and pass `initialPage` + `onNavigate` to `<Settings>`
-7. **CSS**: Add `pui-root` heading/paragraph resets and transform conflict fix to `index.css`
+5. **Frontend**: Implement `useSettings(schemaEndpoint, saveEndpoint)` and `useSettingsPage()` hooks
+6. **Frontend**: Pass `initialPage` + `onNavigate` to `<Settings>`; pass `applyFilters` if using filter hooks
+7. **CSS**: Scope Tailwind preflight/utilities inside your root selectors; add heading/paragraph resets and transform conflict fix
 8. **Tests**: Write `WP_Test_REST_TestCase` tests covering schema, fetch, save each section, partial save, sanitization, auth guard

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Reusable UI components for WordPress plugins. Built with React and designed to w
 - [Project Structure](#project-structure)
 - [Available Scripts](#available-scripts)
 - [Peer Dependencies](#peer-dependencies)
+- [Claude Code Integration](#claude-code-integration)
 - [License](#license)
 
 ## Installation
@@ -523,6 +524,72 @@ npm run lint
    rm -rf node_modules package-lock.json
    npm install
    ```
+
+## Claude Code Integration
+
+This repository ships a **Claude Code skill** that provides AI-assisted guidance for integrating plugin-ui's `<Settings>` component into a WordPress plugin.
+
+### What the skill covers
+
+- First-time setup (install from GitHub or local path)
+- PHP backend: `AbstractSettingsSchema`, field definitions, section-grouped save payload, WP REST arg alignment, partial save / merge pattern
+- Frontend: `useSettings` hook, `useSettingsPage` hook, app structure with `ThemeProvider + Settings + Toaster`
+- CSS: scoped Tailwind preflight/utilities, WordPress admin heading/paragraph resets, Tailwind v3/v4 transform conflict fix
+- Extending fields via filter hooks (`applyFilters`, custom variants)
+- PHPUnit REST API testing (`WP_Test_REST_TestCase`)
+- Common pitfalls checklist
+
+### Requirements
+
+[Claude Code](https://claude.ai/code) CLI installed and running inside your WordPress plugin project.
+
+### Usage
+
+The skill is available as `/settings-integration`. Open Claude Code in your WordPress plugin project and run:
+
+```
+/settings-integration
+```
+
+Claude will read your current codebase to understand the integration state, then guide, scaffold, or fix whatever you ask — for example:
+
+```
+/settings-integration Add a new "Appearance" settings page with color picker fields
+```
+
+```
+/settings-integration Why is my onesignal save returning a 400 error?
+```
+
+```
+/settings-integration Generate the PHPUnit tests for my SettingsController
+```
+
+### Skill file location
+
+The skill file lives in this repository:
+
+```
+plugin-ui/.claude/commands/settings-integration.md
+```
+
+Claude Code only loads slash commands from the `.claude/commands/` directory of the **currently open project**. To use this skill in your plugin, copy it in:
+
+```bash
+mkdir -p .claude/commands
+cp node_modules/@wedevs/plugin-ui/.claude/commands/settings-integration.md .claude/commands/
+```
+
+Or if plugin-ui is a local sibling:
+
+```bash
+mkdir -p .claude/commands
+cp ../plugin-ui/.claude/commands/settings-integration.md .claude/commands/
+```
+
+After copying, the `/settings-integration` command will appear in Claude Code when working in your plugin. Re-copy whenever plugin-ui releases an updated version of the skill.
+
+---
 
 ## License
 

--- a/src/components/license.tsx
+++ b/src/components/license.tsx
@@ -354,9 +354,13 @@ export function License({
               {hasActive ? (
                 <>
                   <AlertDialog open={deactivateDialogOpen} onOpenChange={(open) => { if (!loading) setDeactivateDialogOpen(open); }}>
-                    <AlertDialogTrigger>
-                      <Button variant="destructive" size="sm" disabled={loading}>{labels.deactivateButton}</Button>
-                    </AlertDialogTrigger>
+                    <AlertDialogTrigger
+                      render={ ( props ) => (
+                        <Button { ...props } variant="destructive" size="sm" disabled={ loading }>
+                          { labels.deactivateButton }
+                        </Button>
+                      ) }
+                    />
                     <AlertDialogContent>
                       <AlertDialogHeader>
                         <AlertDialogTitle className="p-0! m-0!">

--- a/src/components/settings/Settings.stories.tsx
+++ b/src/components/settings/Settings.stories.tsx
@@ -5328,7 +5328,7 @@ const dokanSettingsSchema: SettingsElement[] = [
                                 "dependency_key": "vendor_onboarding.vendor_setup_wizard_logo",
                                 "dependencies": [],
                                 "validations": [],
-                                "variant": "file_upload",
+                                "variant": "wp_media_upload",
                                 "value": "",
                                 "default": "",
                                 "placeholder": "+ Choose File",

--- a/src/components/settings/SettingsSkeleton.stories.tsx
+++ b/src/components/settings/SettingsSkeleton.stories.tsx
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState, useEffect } from 'react';
+import { SettingsSkeleton } from './settings-skeleton';
+import { Settings } from './index';
+import type { SettingsElement } from './settings-types';
+
+const meta = {
+    title: 'Settings/SettingsSkeleton',
+    component: SettingsSkeleton,
+    parameters: {
+        layout: 'padded',
+    },
+    tags: ['autodocs'],
+} satisfies Meta<typeof SettingsSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ── Default — standalone skeleton ─────────────────────────────────────────────
+
+export const Default: Story = {};
+
+// ── Compact — narrow container ─────────────────────────────────────────────────
+
+export const Compact: Story = {
+    render: () => (
+        <div className="max-w-2xl">
+            <SettingsSkeleton />
+        </div>
+    ),
+};
+
+// ── Transition — skeleton fades into real Settings ────────────────────────────
+
+const DEMO_SCHEMA: SettingsElement[] = [
+    {
+        id: 'appearance',
+        type: 'page',
+        label: 'Appearance',
+        icon: 'Paintbrush',
+        children: [
+            {
+                id: 'branding',
+                type: 'section',
+                label: 'Branding',
+                description: 'Customise how your plugin looks.',
+                page_id: 'appearance',
+                children: [
+                    {
+                        id: 'app_name',
+                        type: 'field',
+                        variant: 'text',
+                        label: 'App Name',
+                        section_id: 'branding',
+                        value: 'My App',
+                    },
+                    {
+                        id: 'primary_color',
+                        type: 'field',
+                        variant: 'color_picker',
+                        label: 'Primary Color',
+                        section_id: 'branding',
+                        value: '#6366f1',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'notifications',
+        type: 'page',
+        label: 'Notifications',
+        icon: 'Bell',
+        children: [
+            {
+                id: 'push',
+                type: 'section',
+                label: 'Push Notifications',
+                page_id: 'notifications',
+                children: [
+                    {
+                        id: 'enabled',
+                        type: 'field',
+                        variant: 'switch',
+                        label: 'Enable Push Notifications',
+                        section_id: 'push',
+                        value: true,
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+function TransitionDemo() {
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const t = setTimeout(() => setLoading(false), 2500);
+        return () => clearTimeout(t);
+    }, []);
+
+    if (loading) {
+        return <SettingsSkeleton />;
+    }
+
+    return (
+        <Settings
+            title="Plugin Settings"
+            schema={DEMO_SCHEMA}
+            values={{}}
+            onChange={() => {}}
+            onSave={() => {}}
+        />
+    );
+}
+
+export const LoadingTransition: Story = {
+    name: 'Loading → Real Settings (2.5s)',
+    render: () => <TransitionDemo />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'Skeleton shows for 2.5 s then transitions to the real `<Settings>` component — matches the `loading` prop behaviour.',
+            },
+        },
+    },
+};
+
+// ── Via Settings loading prop ──────────────────────────────────────────────────
+
+export const ViaLoadingProp: Story = {
+    name: 'Via Settings loading prop',
+    render: () => (
+        <Settings
+            title="Plugin Settings"
+            schema={[]}
+            values={{}}
+            loading={true}
+            onChange={() => {}}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Pass `loading={true}` to `<Settings>` — it internally renders `<SettingsSkeleton>` automatically.',
+            },
+        },
+    },
+};

--- a/src/components/settings/field-renderer.tsx
+++ b/src/components/settings/field-renderer.tsx
@@ -21,6 +21,8 @@ import {
     RichTextField,
     GoogleAnalyticsField,
     CombineInputField,
+    WpMediaUploadField,
+    WpMediaUploadMultipleField,
 } from './fields';
 
 // ============================================
@@ -221,6 +223,20 @@ export function FieldRenderer({
             return applyFilters(
                 `${filterPrefix}_settings_info_field`,
                 <InfoField {...fieldProps} />,
+                mergedElement
+            );
+
+        case 'wp_media_upload':
+            return applyFilters(
+                `${filterPrefix}_settings_wp_media_upload_field`,
+                <WpMediaUploadField {...fieldProps} />,
+                mergedElement
+            );
+
+        case 'wp_media_upload_multiple':
+            return applyFilters(
+                `${filterPrefix}_settings_wp_media_upload_multiple_field`,
+                <WpMediaUploadMultipleField {...fieldProps} />,
                 mergedElement
             );
 

--- a/src/components/settings/fields.tsx
+++ b/src/components/settings/fields.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { WpMediaUpload, WpMediaUploadMultiple } from '../wordpress/WpMediaUpload';
 import { cn } from "@/lib/utils";
 import * as LucideIcons from "lucide-react";
 import { FileText, Info, Eye, EyeOff, ArrowUpRight, RefreshCcw } from "lucide-react";
@@ -926,6 +927,40 @@ export function CombineInputField({ element, onChange, ...rest }: FieldComponent
         onNumberChange={(val) =>
           onChange(element.dependency_key!, { ...value, [numberKey]: val })
         }
+      />
+    </FieldWrapper>
+  );
+}
+
+// ============================================
+// WP Media Upload Fields
+// ============================================
+
+export function WpMediaUploadField({ element, onChange, ...rest }: FieldComponentProps) {
+  return (
+    <FieldWrapper element={element} layout={element.layout ?? 'horizontal'} {...rest}>
+      <WpMediaUpload
+        value={String(element.value ?? '')}
+        onChange={(url) => onChange(element.dependency_key!, url)}
+        btnText={element.placeholder ? String(element.placeholder) : undefined}
+        disabled={element.disabled}
+      />
+    </FieldWrapper>
+  );
+}
+
+export function WpMediaUploadMultipleField({ element, onChange, ...rest }: FieldComponentProps) {
+  const currentValue = Array.isArray(element.value)
+    ? (element.value as string[])
+    : element.value ? [String(element.value)] : [];
+
+  return (
+    <FieldWrapper element={element} layout={element.layout ?? 'horizontal'} {...rest}>
+      <WpMediaUploadMultiple
+        value={currentValue}
+        onChange={(urls) => onChange(element.dependency_key!, urls)}
+        btnText={element.placeholder ? String(element.placeholder) : undefined}
+        disabled={element.disabled}
       />
     </FieldWrapper>
   );

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -24,6 +24,8 @@ export function Settings({
     hookPrefix = 'plugin_ui',
     className,
     applyFilters,
+    initialPage,
+    onNavigate,
 }: SettingsProps) {
     return (
         <SettingsProvider
@@ -35,6 +37,8 @@ export function Settings({
             loading={loading}
             hookPrefix={hookPrefix}
             applyFilters={applyFilters}
+            initialPage={initialPage}
+            onNavigate={onNavigate}
         >
             <SettingsInner
                 title={title}

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -4,6 +4,7 @@ import { Button } from '../ui/button';
 import { SettingsProvider } from './settings-context';
 import { SettingsSidebar } from './settings-sidebar';
 import { SettingsContent } from './settings-content';
+import { SettingsSkeleton } from './settings-skeleton';
 import { useSettings } from './settings-context';
 import type { SettingsProps } from './settings-types';
 import { Menu, X } from 'lucide-react';
@@ -71,13 +72,7 @@ function SettingsInner({
     }, [activeSubpage, prevSubpage]);
 
     if (loading) {
-        return (
-            <div className={cn('flex items-center justify-center min-h-96', className)}>
-                <div className="flex flex-col items-center gap-3">
-                    <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
-                </div>
-            </div>
-        );
+        return <SettingsSkeleton className={className} />;
     }
 
     return (

--- a/src/components/settings/settings-content.tsx
+++ b/src/components/settings/settings-content.tsx
@@ -43,7 +43,8 @@ export function SettingsContent({ className }: { className?: string }) {
     };
 
     // Determine whether to show a save area
-    const showSaveArea = Boolean(save);
+    // Hidden when the active page/subpage sets hide_save: true (e.g. License page)
+    const showSaveArea = Boolean(save) && !contentSource?.hide_save;
 
     if (!contentSource) {
         return (
@@ -55,6 +56,7 @@ export function SettingsContent({ className }: { className?: string }) {
         <ScrollArea className={cn('flex flex-col overflow-y-auto', className)} data-testid="settings-content">
             <div className="flex-1">
                 {/* Heading */}
+                {!contentSource.hide_heading && (
                 <div className="px-6 pt-6 pb-4" data-testid={`settings-heading-${contentSource.id}`}>
                     <div className="flex justify-between items-start">
                         <div className="flex flex-col gap-2">
@@ -82,6 +84,7 @@ export function SettingsContent({ className }: { className?: string }) {
                         )}
                     </div>
                 </div>
+                )}
 
                 {/* Tabs */}
                 {tabs.length > 0 && (
@@ -176,8 +179,12 @@ function ContentBlock({ element }: { element: SettingsElementType }) {
             );
 
         case 'field':
-            // Direct field under a subpage (no section wrapper)
-            // Wrap in a minimal card for consistent styling
+            // Direct field under a page (no section wrapper).
+            // Fields with no_wrap skip the card — e.g. the license variant
+            // which brings its own full-width card UI.
+            if (element.no_wrap) {
+                return <FieldRenderer element={element} />;
+            }
             return (
                 <div className="rounded-lg border border-border bg-card overflow-hidden" data-testid={`settings-field-block-${element.id}`}>
                     <FieldRenderer element={element} />

--- a/src/components/settings/settings-content.tsx
+++ b/src/components/settings/settings-content.tsx
@@ -4,6 +4,7 @@ import { FieldRenderer } from './field-renderer';
 import { cn } from '@/lib/utils';
 import { FileText, Info } from "lucide-react";
 import { ScrollArea, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui";
+import { Button } from "@/components/ui/button";
 import { RawHTML } from "@wordpress/element";
 
 // ============================================
@@ -137,7 +138,14 @@ export function SettingsContent({ className }: { className?: string }) {
               >
                   {renderSaveButton
                     ? renderSaveButton({ scopeId, dirty, hasErrors, onSave: handleSave })
-                    : null}
+                    : (
+                      <Button
+                        onClick={handleSave}
+                        disabled={!dirty || hasErrors}
+                      >
+                        Save Changes
+                      </Button>
+                    )}
               </div>
             )}
 

--- a/src/components/settings/settings-context.tsx
+++ b/src/components/settings/settings-context.tsx
@@ -96,6 +96,10 @@ export interface SettingsProviderProps {
     hookPrefix?: string;
     /** Optional filter function for extensibility (e.g. @wordpress/hooks applyFilters) */
     applyFilters?: ApplyFiltersFunction;
+    /** Page ID to activate on mount (e.g. read from a URL query param). Falls back to the first page. */
+    initialPage?: string;
+    /** Called whenever the active page changes. Use to sync a URL query param. */
+    onNavigate?: (pageId: string) => void;
 }
 
 export function SettingsProvider({
@@ -108,6 +112,8 @@ export function SettingsProvider({
     loading = false,
     hookPrefix = 'plugin_ui',
     applyFilters: applyFiltersProp,
+    initialPage,
+    onNavigate,
 }: SettingsProviderProps) {
     // Format schema (handles both flat and hierarchical)
     const schema = useMemo(() => formatSettingsData(rawSchema), [rawSchema]);
@@ -198,21 +204,21 @@ export function SettingsProvider({
         setPrevLoading(loading);
     }, [defaultValues, externalValues, loading, prevLoading]);
 
-    // Auto-select first page/subpage on schema load
+    // Auto-select page/subpage on schema load.
+    // Prefers initialPage (e.g. from a URL query param) over the first page.
     useEffect(() => {
         if (schema.length > 0 && !activePage) {
-            const firstPage = schema[0];
-            setActivePage(firstPage.id);
+            const targetPage = (initialPage && schema.find((p) => p.id === initialPage)) || schema[0];
+            setActivePage(targetPage.id);
 
-            const firstSubpage = firstPage.children?.find((c) => c.type === 'subpage');
+            const firstSubpage = targetPage.children?.find((c) => c.type === 'subpage');
             if (firstSubpage) {
                 setActiveSubpage(firstSubpage.id);
                 const firstTab = firstSubpage.children?.find((c) => c.type === 'tab');
                 if (firstTab) setActiveTab(firstTab.id);
             } else {
-                // Page without subpages — check for direct tabs
                 setActiveSubpage('');
-                const firstTab = firstPage.children?.find((c) => c.type === 'tab');
+                const firstTab = targetPage.children?.find((c) => c.type === 'tab');
                 setActiveTab(firstTab?.id || '');
             }
         }
@@ -361,6 +367,7 @@ export function SettingsProvider({
     const handleSetActivePage = useCallback(
         (pageId: string) => {
             setActivePage(pageId);
+            onNavigate?.(pageId);
             const page = schema.find((p) => p.id === pageId);
             if (page?.children?.length) {
                 const firstSubpage = page.children.find((c) => c.type === 'subpage');
@@ -376,7 +383,7 @@ export function SettingsProvider({
                 }
             }
         },
-        [schema]
+        [schema, onNavigate]
     );
 
     const handleSetActiveSubpage = useCallback(

--- a/src/components/settings/settings-skeleton.tsx
+++ b/src/components/settings/settings-skeleton.tsx
@@ -1,0 +1,112 @@
+import { cn } from '@/lib/utils';
+import { Skeleton } from '../ui/skeleton';
+
+// ============================================
+// Settings Skeleton — matches the real layout
+// ============================================
+
+export function SettingsSkeleton({ className }: { className?: string }) {
+    return (
+        <div
+            className={cn(
+                'relative flex min-h-[500px] rounded-lg border border-border bg-background overflow-hidden',
+                className
+            )}
+            aria-busy="true"
+            aria-label="Loading settings"
+        >
+            {/* ── Sidebar ── */}
+            <aside className="hidden lg:flex lg:w-64 shrink-0 flex-col border-r border-border bg-muted/30 p-3 gap-2">
+                {/* Title */}
+                <div className="px-1 py-2 border-b border-border mb-1">
+                    <Skeleton className="h-4 w-32" />
+                </div>
+                {/* Search bar */}
+                <Skeleton className="h-8 w-full rounded-md" />
+                {/* Nav items */}
+                <SidebarNavSkeleton />
+            </aside>
+
+            {/* ── Content ── */}
+            <div className="flex flex-1 min-w-0 flex-col">
+                <ContentSkeleton />
+            </div>
+        </div>
+    );
+}
+
+// ── Sidebar nav items ─────────────────────────────────────────────────────────
+
+function SidebarNavSkeleton() {
+    return (
+        <nav className="flex flex-col gap-1 mt-1">
+            {[80, 64, 72, 56, 68].map((w, i) => (
+                <div key={i} className="flex items-center gap-2 px-2 py-1.5">
+                    <Skeleton className="size-4 shrink-0 rounded" />
+                    <Skeleton className="h-3.5 rounded" style={{ width: w }} />
+                </div>
+            ))}
+        </nav>
+    );
+}
+
+// ── Content area ──────────────────────────────────────────────────────────────
+
+function ContentSkeleton() {
+    return (
+        <div className="flex flex-col flex-1 overflow-hidden">
+            {/* Page heading */}
+            <div className="px-6 pt-6 pb-4 border-b border-border">
+                <Skeleton className="h-7 w-48 mb-2" />
+                <Skeleton className="h-4 w-72" />
+            </div>
+
+            {/* Tabs */}
+            <div className="px-6 border-b border-border flex gap-6 py-2.5">
+                {[48, 64, 56].map((w, i) => (
+                    <Skeleton key={i} className="h-4 rounded" style={{ width: w }} />
+                ))}
+            </div>
+
+            {/* Sections */}
+            <div className="p-6 space-y-6">
+                <SectionSkeleton fieldCount={3} />
+                <SectionSkeleton fieldCount={2} />
+            </div>
+        </div>
+    );
+}
+
+// ── Single section ────────────────────────────────────────────────────────────
+
+function SectionSkeleton({ fieldCount }: { fieldCount: number }) {
+    return (
+        <div className="rounded-lg border border-border bg-card overflow-hidden">
+            {/* Section header */}
+            <div className="px-5 pt-5 pb-3 border-b border-border">
+                <Skeleton className="h-5 w-40 mb-1.5" />
+                <Skeleton className="h-3.5 w-64" />
+            </div>
+            {/* Fields */}
+            <div className="divide-y divide-border">
+                {Array.from({ length: fieldCount }).map((_, i) => (
+                    <FieldSkeleton key={i} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+// ── Single field row ──────────────────────────────────────────────────────────
+
+function FieldSkeleton() {
+    return (
+        <div className="flex items-center justify-between px-5 py-4 gap-4">
+            <div className="flex flex-col gap-1.5 flex-1">
+                <Skeleton className="h-4 w-36" />
+                <Skeleton className="h-3.5 w-56" />
+            </div>
+            <Skeleton className="h-6 w-10 shrink-0 rounded-full" />
+        </div>
+    );
+}

--- a/src/components/settings/settings-types.ts
+++ b/src/components/settings/settings-types.ts
@@ -174,6 +174,10 @@ export interface SettingsProps {
      * If not provided, fields render without filtering.
      */
     applyFilters?: (hookName: string, value: any, ...args: any[]) => any;
+    /** Page ID to activate on mount (e.g. read from a URL query param). Falls back to the first page. */
+    initialPage?: string;
+    /** Called whenever the active page changes. Use to sync a URL query param. */
+    onNavigate?: (pageId: string) => void;
 }
 
 export interface FieldComponentProps {

--- a/src/components/wordpress/WpMediaUpload.stories.tsx
+++ b/src/components/wordpress/WpMediaUpload.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { useState } from 'react';
+import { WpMediaUpload, WpMediaUploadMultiple } from './WpMediaUpload';
+
+// ── Mock wp.media for Storybook (not available outside WordPress) ─────────────
+
+const SAMPLE_IMAGE = 'https://placehold.co/400x400/e2e8f0/475569?text=Logo';
+const SAMPLE_IMAGES = [
+    'https://placehold.co/400x400/e2e8f0/475569?text=Image+1',
+    'https://placehold.co/400x400/dbeafe/1d4ed8?text=Image+2',
+    'https://placehold.co/400x400/dcfce7/15803d?text=Image+3',
+];
+
+function mockWpMedia( multiple = false ) {
+    ( window as any ).wp = {
+        media: ( _options: object ) => {
+            let selectCb: (() => void) | null = null;
+            const urls = multiple ? SAMPLE_IMAGES.slice( 0, 2 ) : [ SAMPLE_IMAGE ];
+            return {
+                on: ( event: string, cb: () => void ) => {
+                    if ( event === 'select' ) selectCb = cb;
+                },
+                once: ( event: string, cb: () => void ) => {
+                    if ( event === 'select' ) selectCb = cb;
+                },
+                open: () => {
+                    // Simulate async media selection
+                    setTimeout( () => selectCb?.(), 300 );
+                },
+                state: () => ( {
+                    get: ( key: string ) => {
+                        if ( key !== 'selection' ) return null;
+                        if ( multiple ) {
+                            const items = urls.map( ( url ) => ( { toJSON: () => ( { url } ) } ) );
+                            return {
+                                map: ( fn: ( a: any ) => any ) => items.map( fn ),
+                                each: ( fn: ( a: any ) => void ) => items.forEach( fn ),
+                                pop: () => items.pop(),
+                            };
+                        }
+                        const item = { toJSON: () => ( { url: urls[0] } ) };
+                        return {
+                            map: ( fn: ( a: any ) => any ) => [ item ].map( fn ),
+                            each: ( fn: ( a: any ) => void ) => [ item ].forEach( fn ),
+                            first: () => item,
+                            pop: () => item.toJSON(),
+                        };
+                    },
+                } ),
+            };
+        },
+    };
+}
+
+// ── Single ────────────────────────────────────────────────────────────────────
+
+const SingleMeta = {
+    title: 'WordPress/WpMediaUpload',
+    component: WpMediaUpload,
+    parameters: { layout: 'centered' },
+    tags: ['autodocs'],
+    args: {
+        onChange: fn(),
+    },
+    argTypes: {
+        value: { control: 'text' },
+        btnText: { control: 'text' },
+        disabled: { control: 'boolean' },
+    },
+    decorators: [
+        ( Story: any ) => {
+            mockWpMedia( false );
+            return <Story />;
+        },
+    ],
+} satisfies Meta<typeof WpMediaUpload>;
+
+export default SingleMeta;
+
+type SingleStory = StoryObj<typeof SingleMeta>;
+
+export const Empty: SingleStory = {
+    args: {
+        btnText: 'Upload Logo',
+    },
+};
+
+export const WithPreview: SingleStory = {
+    args: {
+        value: SAMPLE_IMAGE,
+        btnText: 'Upload Logo',
+    },
+};
+
+export const Disabled: SingleStory = {
+    args: {
+        value: SAMPLE_IMAGE,
+        btnText: 'Upload Logo',
+        disabled: true,
+    },
+};
+
+/** Interactive — click "Upload Image" to simulate a media library selection. */
+export const Interactive: SingleStory = {
+    render: ( args ) => {
+        const [ value, setValue ] = useState( args.value ?? '' );
+        return <WpMediaUpload { ...args } value={ value } onChange={ setValue } />;
+    },
+    args: {},
+};
+
+// ── Multiple ──────────────────────────────────────────────────────────────────
+
+export const Multiple: StoryObj<typeof WpMediaUploadMultiple> = {
+    render: () => {
+        const [ values, setValues ] = useState<string[]>( [] );
+        mockWpMedia( true );
+        return (
+            <WpMediaUploadMultiple
+                value={ values }
+                onChange={ setValues }
+                btnText="Add Images"
+            />
+        );
+    },
+};
+
+export const MultipleWithExisting: StoryObj<typeof WpMediaUploadMultiple> = {
+    render: () => {
+        const [ values, setValues ] = useState<string[]>( SAMPLE_IMAGES );
+        mockWpMedia( true );
+        return (
+            <WpMediaUploadMultiple
+                value={ values }
+                onChange={ setValues }
+                btnText="Add Images"
+            />
+        );
+    },
+};

--- a/src/components/wordpress/WpMediaUpload.stories.tsx
+++ b/src/components/wordpress/WpMediaUpload.stories.tsx
@@ -102,40 +102,34 @@ export const Disabled: SingleStory = {
 };
 
 /** Interactive — click "Upload Image" to simulate a media library selection. */
+function InteractiveRender( args: React.ComponentProps<typeof WpMediaUpload> ) {
+    const [ value, setValue ] = useState( args.value ?? '' );
+    return <WpMediaUpload { ...args } value={ value } onChange={ setValue } />;
+}
+
 export const Interactive: SingleStory = {
-    render: ( args ) => {
-        const [ value, setValue ] = useState( args.value ?? '' );
-        return <WpMediaUpload { ...args } value={ value } onChange={ setValue } />;
-    },
+    render: ( args ) => <InteractiveRender { ...args } />,
     args: {},
 };
 
 // ── Multiple ──────────────────────────────────────────────────────────────────
 
+function MultipleRender( { initial = [] }: { initial?: string[] } ) {
+    const [ values, setValues ] = useState<string[]>( initial );
+    mockWpMedia( true );
+    return (
+        <WpMediaUploadMultiple
+            value={ values }
+            onChange={ setValues }
+            btnText="Add Images"
+        />
+    );
+}
+
 export const Multiple: StoryObj<typeof WpMediaUploadMultiple> = {
-    render: () => {
-        const [ values, setValues ] = useState<string[]>( [] );
-        mockWpMedia( true );
-        return (
-            <WpMediaUploadMultiple
-                value={ values }
-                onChange={ setValues }
-                btnText="Add Images"
-            />
-        );
-    },
+    render: () => <MultipleRender />,
 };
 
 export const MultipleWithExisting: StoryObj<typeof WpMediaUploadMultiple> = {
-    render: () => {
-        const [ values, setValues ] = useState<string[]>( SAMPLE_IMAGES );
-        mockWpMedia( true );
-        return (
-            <WpMediaUploadMultiple
-                value={ values }
-                onChange={ setValues }
-                btnText="Add Images"
-            />
-        );
-    },
+    render: () => <MultipleRender initial={ SAMPLE_IMAGES } />,
 };

--- a/src/components/wordpress/WpMediaUpload.tsx
+++ b/src/components/wordpress/WpMediaUpload.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { Upload, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import wpMedia from '@/lib/WpMedia';
+
+// ─── Single ───────────────────────────────────────────────────────────────────
+
+export interface WpMediaUploadProps {
+    value?: string;
+    onChange: ( url: string ) => void;
+    btnText?: string;
+    className?: string;
+    disabled?: boolean;
+}
+
+export function WpMediaUpload( {
+    value,
+    onChange,
+    btnText = 'Upload Image',
+    className,
+    disabled,
+}: WpMediaUploadProps ) {
+    const handleUpload = () => {
+        wpMedia( ( file ) => {
+            const url = Array.isArray( file ) ? ( file[0]?.url ?? '' ) : ( file as { url: string } ).url;
+            onChange( url );
+        } );
+    };
+
+    return (
+        <div className={ cn( 'flex flex-col items-end gap-2', className ) }>
+            { value && (
+                <div className="relative inline-flex">
+                    <img
+                        src={ value }
+                        alt=""
+                        className="h-16 w-16 rounded-md border border-border bg-muted object-contain p-1"
+                    />
+                    <button
+                        type="button"
+                        disabled={ disabled }
+                        title="Remove"
+                        onClick={ () => onChange( '' ) }
+                        className="absolute -right-2 -top-2 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <X size={ 10 } strokeWidth={ 3 } />
+                    </button>
+                </div>
+            ) }
+            <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={ disabled }
+                onClick={ handleUpload }
+                className="gap-1.5"
+            >
+                <Upload size={ 14 } />
+                { value ? 'Change' : btnText }
+            </Button>
+        </div>
+    );
+}
+
+// ─── Multiple ─────────────────────────────────────────────────────────────────
+
+export interface WpMediaUploadMultipleProps {
+    value?: string[];
+    onChange: ( urls: string[] ) => void;
+    btnText?: string;
+    className?: string;
+    disabled?: boolean;
+}
+
+export function WpMediaUploadMultiple( {
+    value = [],
+    onChange,
+    btnText = 'Add Images',
+    className,
+    disabled,
+}: WpMediaUploadMultipleProps ) {
+    const handleUpload = () => {
+        // @ts-expect-error wp.media is not defined in the global scope
+        const frame = wp.media( {
+            title: 'Select Images',
+            button: { text: 'Add' },
+            multiple: true,
+        } );
+
+        frame.once( 'select', () => {
+            const selection = frame.state().get( 'selection' );
+            const newUrls: string[] = [];
+            selection.each( ( attachment: { toJSON: () => { url: string } } ) => {
+                newUrls.push( attachment.toJSON().url );
+            } );
+            onChange( [ ...value, ...newUrls ] );
+        } );
+
+        frame.open();
+    };
+
+    const remove = ( index: number ) => {
+        onChange( value.filter( ( _, i ) => i !== index ) );
+    };
+
+    return (
+        <div className={ cn( 'flex flex-col items-end gap-2', className ) }>
+            { value.length > 0 && (
+                <div className="flex flex-wrap justify-end gap-2">
+                    { value.map( ( url, i ) => (
+                        <div key={ i } className="relative inline-flex">
+                            <img
+                                src={ url }
+                                alt=""
+                                className="h-14 w-14 rounded-md border border-border bg-muted object-contain p-1"
+                            />
+                            <button
+                                type="button"
+                                disabled={ disabled }
+                                title="Remove"
+                                onClick={ () => remove( i ) }
+                                className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                <X size={ 10 } strokeWidth={ 3 } />
+                            </button>
+                        </div>
+                    ) ) }
+                </div>
+            ) }
+            <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={ disabled }
+                onClick={ handleUpload }
+                className="gap-1.5"
+            >
+                <Upload size={ 14 } />
+                { btnText }
+            </Button>
+        </div>
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,6 +362,7 @@ export {
     type SettingsElement,
     type FieldComponentProps,
 } from './components/settings';
+export { SettingsSkeleton } from './components/settings/settings-skeleton';
 
 // ============================================
 // Theme Presets

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,6 +333,12 @@ export { MatricsPill, type MatricsPillProps } from './components/matrics-pill';
 export { FileUpload, type FileUploadProps } from './components/file-upload';
 export { FileView, type FileViewProps, } from './components/file-view';
 export {
+    WpMediaUpload,
+    type WpMediaUploadProps,
+    WpMediaUploadMultiple,
+    type WpMediaUploadMultipleProps,
+} from './components/wordpress/WpMediaUpload';
+export {
     Logo,
     type LogoProps,
     YoutubeCircleLightLogo,

--- a/src/lib/WpMedia.ts
+++ b/src/lib/WpMedia.ts
@@ -51,41 +51,27 @@ export default function wpMedia(
     callback: ( media: IWpMediaData ) => void,
     media?: null
 ) {
-    let fileFrame = null;
-
-    if ( fileFrame ) {
-        fileFrame.open();
-        return;
-    }
-
     const mediaOptions = {
         title: 'Select',
         button: {
             text: 'Select',
-            close: false,
         },
         multiple: false,
     };
 
     // @ts-expect-error wp.media is not defined in the global scope
-    fileFrame = media ? media : wp.media( mediaOptions );
+    const fileFrame = media ? media : wp.media( mediaOptions );
 
-    fileFrame.on( 'select', () => {
+    fileFrame.once( 'select', () => {
         const selection = fileFrame.state().get( 'selection' );
 
-        const files = selection.map( ( attachment ) => {
+        const files = selection.map( ( attachment: { toJSON: () => IWpMedia } ) => {
             return attachment.toJSON();
         } );
 
         const file = files.pop();
 
         callback( file );
-        console.log(fileFrame);
-        fileFrame = null;
-    } );
-
-    fileFrame.on( 'close', () => {
-        fileFrame = null;
     } );
 
     fileFrame.open();


### PR DESCRIPTION
## Summary

- **New `wp_media_upload` and `wp_media_upload_multiple` field variants** — first-class built-in settings field types that open the WordPress Media Library, with thumbnail preview and remove button, using the same horizontal label/input layout as `TextField`
- **Fix `WpMedia.ts` crash** — `close: false` on the button caused the `close` event to fire before `select`, setting `fileFrame` to `null` and crashing on `fileFrame.state()`. Removed `close: false`, switched `on()` → `once()`, removed dead code and stray `console.log`
- **Default Save button** — `settings-content.tsx` now renders a default "Save Changes" button when `renderSaveButton` prop is not provided, disabled until the form is dirty

## Changes

| File | Change |
|---|---|
| `src/lib/WpMedia.ts` | Fix null-reference crash on media selection |
| `src/components/wordpress/WpMediaUpload.tsx` | New `WpMediaUpload` + `WpMediaUploadMultiple` input components |
| `src/components/wordpress/WpMediaUpload.stories.tsx` | Storybook stories with mocked `wp.media` |
| `src/components/settings/fields.tsx` | `WpMediaUploadField` + `WpMediaUploadMultipleField` wrappers |
| `src/components/settings/field-renderer.tsx` | Register `wp_media_upload` and `wp_media_upload_multiple` cases |
| `src/components/settings/settings-content.tsx` | Default Save Changes button |
| `src/components/settings/Settings.stories.tsx` | Update `vendor_setup_wizard_logo` variant to `wp_media_upload` |
| `src/index.ts` | Export new components and types |

## Usage

In a PHP settings schema:
```php
// Single image
['variant' => 'wp_media_upload', 'dependency_key' => 'app_logo', ...]

// Multiple images
['variant' => 'wp_media_upload_multiple', 'dependency_key' => 'gallery', ...]
```

## Test plan

- [ ] Open Storybook → **WordPress/WpMediaUpload** — verify all stories render correctly
- [ ] Check `Empty`, `WithPreview`, `Disabled`, `Interactive` single stories
- [ ] Check `Multiple` and `MultipleWithExisting` stories — click "Add Images", verify thumbnails appear and × removes them
- [ ] Verify `vendor_setup_wizard_logo` in Dokan settings story renders `WpMediaUploadField` (not fallback)
- [ ] Verify default Save button appears and is disabled until a field is changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single and multiple WordPress media upload fields with previews, remove controls, and upload/change flows.
  * Settings now accepts initialPage and onNavigate for external navigation control.
  * Added SettingsSkeleton loading placeholder and accompanying stories.

* **UX Improvements**
  * Per-scope sticky save area shows a default "Save Changes" button when absent.
  * Respect hide_save, hide_heading, and element.no_wrap to adjust rendering.
  * Logo/upload setting now uses the WordPress media upload variant.

* **Documentation**
  * Added end-to-end Settings integration guide and README section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->