### PR TITLE
feat(settings): support plain field-id keys for dependency lookups

### DIFF
--- a/src/components/settings/settings-context.tsx
+++ b/src/components/settings/settings-context.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import type { SaveButtonRenderProps, SettingsElement } from './settings-types';
 import {
+    buildIdIndex,
     evaluateDependencies,
     extractValues,
     formatSettingsData,
@@ -355,12 +356,18 @@ export function SettingsProvider({
         [schema, onChange, keyToScopeMap, activeSubpage, activePage]
     );
 
+    // Field-id → dependency_key index, used as a fallback when a dependency
+    // declares its `key` as a plain field id instead of the reconstructed
+    // dot-path. Memoized on the schema since ids and dep_keys don't change
+    // at runtime.
+    const idIndex = useMemo(() => buildIdIndex(schema), [schema]);
+
     // Dependency evaluation
     const shouldDisplay = useCallback(
         (element: SettingsElement): boolean => {
-            return evaluateDependencies(element, values);
+            return evaluateDependencies(element, values, idIndex);
         },
-        [values]
+        [values, idIndex]
     );
 
     // Navigation helpers

--- a/src/components/settings/settings-formatter.ts
+++ b/src/components/settings/settings-formatter.ts
@@ -295,11 +295,63 @@ export function extractValues(
 }
 
 /**
+ * Builds a `{ field_id: dependency_key }` map from a hierarchical schema.
+ *
+ * Used by `evaluateDependencies` to resolve a dependency `key` that is
+ * declared as a plain field id (e.g. `"product_info_generate"`) instead
+ * of the full reconstructed dot-path (e.g.
+ * `"product_generation.product_image_section.product_info_generate"`).
+ *
+ * Consumers may pass id-keyed dependencies when their backend already
+ * guarantees globally-unique field ids; the dot-path remains supported
+ * for backwards compatibility.
+ */
+export function buildIdIndex(
+    schema: SettingsElement[]
+): Record<string, string> {
+    const idIndex: Record<string, string> = {};
+
+    const walk = (elements: SettingsElement[]) => {
+        for (const el of elements) {
+            if (
+                el.type === 'field' &&
+                el.id &&
+                el.dependency_key &&
+                el.id !== el.dependency_key
+            ) {
+                // First writer wins — if two fields share an id (a schema
+                // bug consumers should detect with their own validator),
+                // we don't silently clobber the earlier mapping.
+                if (!(el.id in idIndex)) {
+                    idIndex[el.id] = el.dependency_key;
+                }
+            }
+            if (el.children && el.children.length > 0) {
+                walk(el.children);
+            }
+        }
+    };
+
+    walk(schema);
+    return idIndex;
+}
+
+/**
  * Evaluates whether a field should be displayed based on its dependencies.
+ *
+ * Dependency `key` resolution:
+ * 1. Look up `values[dep.key]` directly (existing dot-path behavior).
+ * 2. If that yields `undefined` and an `idIndex` is supplied, treat
+ *    `dep.key` as a plain field id and resolve via `idIndex[dep.key]`
+ *    to its real `dependency_key` before reading from `values`.
+ *
+ * The `idIndex` is optional. When omitted, behavior is identical to the
+ * previous version of this function.
  */
 export function evaluateDependencies(
     element: SettingsElement,
-    values: Record<string, any>
+    values: Record<string, any>,
+    idIndex?: Record<string, string>
 ): boolean {
     if (!element.dependencies || element.dependencies.length === 0) {
         return element.display !== false;
@@ -308,7 +360,18 @@ export function evaluateDependencies(
     return element.dependencies.every((dep) => {
         if (!dep.key) return true;
 
-        const currentValue = values[dep.key];
+        let currentValue = values[dep.key];
+
+        // Field-id fallback: dep.key may be a plain id (not a dot-path).
+        // Resolve it through the idIndex to the underlying dependency_key
+        // and re-read from values.
+        if (currentValue === undefined && idIndex) {
+            const resolved = idIndex[dep.key];
+            if (resolved !== undefined) {
+                currentValue = values[resolved];
+            }
+        }
+
         const comparison = dep.comparison || '==';
         const expectedValue = dep.value;
         const effect = dep.effect || 'show';


### PR DESCRIPTION
## Summary

- Adds an additive id-keyed fallback to `evaluateDependencies()` so dependencies declared with a plain field id (`'commission_type'`) resolve correctly alongside the existing dot-path format (`'commission.commission.commission_type'`).
- Exports a new `buildIdIndex(schema)` helper from `settings-formatter` that maps each field's `id` to its reconstructed `dependency_key`.
- `SettingsProvider` builds the index (memoised on `schema`) and threads it through `shouldDisplay → evaluateDependencies`.

## Why

`formatSettingsData()` rebuilds every element's `dependency_key` as a `parent.child.field` dot-path and uses that as the values-map key. Consumers whose backend declares dependencies with plain field ids (the schema is the source of truth for which field they reference) silently fail to resolve because `values[dep.key]` returns `undefined`.

Dokan's settings refactor lands on a flat-storage model where every field id is globally unique; the natural way to reference fields is by id, not by structural path. Path-based keys also break on structural reorganization (moving a field changes its dot-path), while id-based keys remain stable.

## Behavior

```ts
// Dot-path (existing — still works):
{ key: 'commission.commission.commission_type', value: 'category_based', effect: 'show' }

// Plain id (new — also works):
{ key: 'commission_type', value: 'category_based', effect: 'show' }
```

Resolution order in `evaluateDependencies()`:
1. `values[dep.key]` direct lookup (existing behavior).
2. If `undefined` and an `idIndex` is supplied, `values[idIndex[dep.key]]`.

## Backwards Compatibility

- `evaluateDependencies()`'s third `idIndex` parameter is **optional**. Callers that don't pass it see byte-identical behavior.
- No changes to `extractValues()`, `updateValue`, or the values-map shape.
- Existing dot-path dependencies in consumer schemas continue to resolve via the direct lookup path.

## Test plan

- [ ] Run the existing Settings stories — dot-path dependencies still drive visibility correctly.
- [ ] Add a fixture with a plain-id dependency and verify it resolves (matches `target field's value`).
- [ ] Verify a dependency with neither a matching dot-path nor a matching id falls through to `currentValue === undefined`, preserving the legacy fail-closed behavior.
- [ ] No regressions in dirty tracking, save handlers, or initial-page selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the settings dependency evaluation system to more reliably resolve field visibility conditions, improving support for complex interdependent settings configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getdokan/plugin-ui/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->