### PR TITLE
Add actionsLabel prop on DataViews for i18n override

### DIFF
--- a/src/components/wordpress/dataviews.tsx
+++ b/src/components/wordpress/dataviews.tsx
@@ -278,6 +278,7 @@ export type DataViewsProps<Item> = {
     search?: boolean;
     searchLabel?: string;
     searchPlaceholder?: string;
+    actionsLabel?: string;
     actions?: DataViewAction<Item>[];
     data: Item[];
     isLoading?: boolean;
@@ -455,6 +456,7 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
         tabs,
         search,
         searchPlaceholder = __('Search', 'default'),
+        actionsLabel = __('Actions', 'default'),
         children,
         ...dataViewsTableProps
     } = props;
@@ -974,7 +976,7 @@ export function DataViews<Item>(props: DataViewsProps<Item>) {
                                 hasBulkActions={!!props.onChangeSelection}
                                 headers={[
                                     ...fields.map((f) => f.label ?? f.id),
-                                    ...(props.actions?.length ? [__('Actions', 'default')] : [])
+                                    ...(props.actions?.length ? [actionsLabel] : [])
                                 ]}
                             />
                         ) : (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Promote the actions column header label on `<DataViews>` to an overridable prop. Mirrors the existing pattern used for `searchPlaceholder` and the `FilterItems` `labels` block: the default value remains `__('Actions', 'default')` so behavior is unchanged for every existing consumer.

This unlocks consumers that need to render the label through a different text domain — e.g. WordPress frontend pages where the core `'default'` text domain translations aren't loaded — without forking the component.

### Related Pull Request(s)

* getdokan/dokan#3204 — Lite consumes this prop on the vendor-dashboard product list
* getdokan/dokan-pro#5655 — Pro companion PR (script translation registration)

### Closes

* Related to getdokan/dokan-pro#5647

### How to test the changes in this Pull Request:

1. In a consumer codebase, render `<DataViews>` with at least one `action` and `actionsLabel={ __( 'Actions', 'your-text-domain' ) }`.
2. Confirm the actions column header (during the loading skeleton) renders using the consumer's text domain.
3. Confirm existing consumers that do not pass `actionsLabel` behave identically.

### Changelog entry

*Add \`actionsLabel\` prop to \`<DataViews>\` for i18n override*

The skeleton state of `<DataViews>` previously hardcoded the actions column label as `__('Actions', 'default')`, which prevented consumers from localizing the label through their own text domain in contexts where the core `'default'` translation isn't loaded. The new `actionsLabel` prop defaults to the previous value but accepts any string so the label can be routed through a domain that ships the right translation.

### Before Changes

`<DataViews>` actions column header (in the loading skeleton) reads English "Actions" on WordPress frontend pages even when a translation exists in the host plugin's text domain.

### After Changes

Consumers can pass `actionsLabel={ __( 'Actions', 'my-plugin' ) }` so the column header is translated through the host plugin's domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading skeleton tables now support customizable action column labels, allowing for localized or context-specific action descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getdokan/plugin-ui/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->