### PR TITLE
feat(settings): render per-option icons in SelectField

### DIFF
--- a/src/components/settings/fields.tsx
+++ b/src/components/settings/fields.tsx
@@ -419,6 +419,16 @@ export function SelectField({ element, onChange, ...rest }: FieldComponentProps)
   );
   const selectedLabel = selectedOption?.label ?? selectedOption?.title;
 
+  // Resolve a per-option icon by lucide name (same convention as `element.icon`).
+  const renderOptionIcon = (iconName?: string) => {
+    if (!iconName) return null;
+    const Icon = LucideIcons[
+      iconName as keyof typeof LucideIcons
+    ] as React.ElementType | undefined;
+    return Icon ? <Icon className="size-4 shrink-0" /> : null;
+  };
+  const selectedIcon = (selectedOption as { icon?: string } | undefined)?.icon;
+
   return (
     <FieldWrapper element={element} {...rest}>
       <Select
@@ -432,12 +442,14 @@ export function SelectField({ element, onChange, ...rest }: FieldComponentProps)
               element.placeholder ? String(element.placeholder) : "Select..."
             }
           >
+            {renderOptionIcon(selectedIcon)}
             {selectedLabel}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {element.options?.map((option) => (
             <SelectItem key={String(option.value)} value={String(option.value)}>
+              {renderOptionIcon((option as { icon?: string }).icon)}
               {option.label ?? option.title}
             </SelectItem>
           ))}


### PR DESCRIPTION
## Summary
The settings `select` field variant (`SelectField`) now renders a per-option **icon** in both the **dropdown items** and the **selected-value trigger**.

Icons are resolved via the existing convention used elsewhere in `fields.tsx` (`LucideIcons[name]`), so an option just needs `icon: '<LucideName>'`:

```ts
options: [
  { title: 'Check Circle (Solid)', value: 'check_circle_solid', icon: 'CircleCheckBig' },
  // ...
]
```

Options **without** `icon` render exactly as before — the change is additive and backward-compatible. No primitive (`SelectItem`/`SelectValue`) changes were needed; the trigger CSS already sizes child `svg`s.

## Why
Enables icon-style selects like the vendor **"Verified Icon"** picker (icon shown per row + for the current selection) without a bespoke custom field renderer in each consumer.

## Notes / scope
- Only the **lucide-name** form is supported (string). Image-URL / raw-inline-SVG were intentionally left out for now (theming via `currentColor`, design-system consistency, and avoiding `dangerouslySetInnerHTML`); can be added later behind a real use case (image-URL is the safe extension).
- `settings-formatter.ts` already preserves `icon` on options (`{ ...opt, icon }`), so no formatter change required.

## Testing
Verified live in Dokan admin settings (`verified_icon` field): icons render in the dropdown list and the selected trigger value; options without an icon are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings select fields now display icons alongside each dropdown option and adjacent to the currently selected value. Icons are automatically resolved from existing naming conventions used throughout the application, ensuring consistent and unified visual representation. This enhancement removes the need for manual icon configuration when adding new settings options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->