### PR TITLE
feat(settings): add collapsible_switch field variant

### DIFF
--- a/src/components/settings/Settings.stories.tsx
+++ b/src/components/settings/Settings.stories.tsx
@@ -17820,3 +17820,89 @@ export const DokanSettings: Story = {
     },
     render: (args) => <SettingsStoryWrapper {...args} />,
 };
+
+// ============================================
+// Collapsible Switch — toggle + chevron header revealing nested config
+// ============================================
+
+const collapsibleSwitchSchema: SettingsElement[] = [
+    { id: 'integrations', type: 'page', label: 'Integrations', icon: 'Plug', priority: 10 },
+    {
+        id: 'social_connect',
+        type: 'section',
+        label: 'Social Connect',
+        description: 'Let users verify their identity through social providers.',
+        page_id: 'integrations',
+        priority: 10,
+    },
+
+    // ── Facebook (collapsible_switch) ──
+    {
+        id: 'facebook_enabled',
+        type: 'field',
+        variant: 'collapsible_switch',
+        section_id: 'social_connect',
+        title: 'Facebook',
+        description: 'Configure your Facebook API settings.',
+        image_url: image,
+        collapsed: true,
+        default: 'off',
+        enable_state: { label: 'Enabled', value: 'on' },
+        disable_state: { label: 'Disabled', value: 'off' },
+    },
+    {
+        id: 'facebook_notice',
+        type: 'field',
+        variant: 'info',
+        field_group_id: 'facebook_enabled',
+        title: "Create an App if you don't have one, then fill in the App ID and Secret below.",
+        link_title: 'Create an App',
+        link_url: 'https://developers.facebook.com/apps/',
+        show_icon: true,
+    },
+    { id: 'facebook_app_id', type: 'field', variant: 'show_hide', field_group_id: 'facebook_enabled', title: 'App ID' },
+    { id: 'facebook_app_secret', type: 'field', variant: 'show_hide', field_group_id: 'facebook_enabled', title: 'App Secret' },
+    {
+        id: 'facebook_redirect_url',
+        type: 'field',
+        variant: 'copy_field',
+        field_group_id: 'facebook_enabled',
+        title: 'Site URL',
+        description: 'Your store URL, which will be required in creating the App.',
+        readonly: true,
+        default: 'https://example.com/wc-api/social-verification/',
+    },
+
+    // ── Google (collapsible_switch) ──
+    {
+        id: 'google_enabled',
+        type: 'field',
+        variant: 'collapsible_switch',
+        section_id: 'social_connect',
+        title: 'Google',
+        description: 'Configure your Google API settings.',
+        image_url: image2,
+        collapsed: true,
+        default: 'off',
+        enable_state: { label: 'Enabled', value: 'on' },
+        disable_state: { label: 'Disabled', value: 'off' },
+    },
+    { id: 'google_client_id', type: 'field', variant: 'show_hide', field_group_id: 'google_enabled', title: 'Client ID' },
+    { id: 'google_client_secret', type: 'field', variant: 'show_hide', field_group_id: 'google_enabled', title: 'Client Secret' },
+];
+
+/**
+ * `collapsible_switch` — a settings field whose header row carries an icon,
+ * title, description, an enable **toggle**, AND a **chevron**. The toggle
+ * persists the field value; the chevron expands/collapses the nested children
+ * (attached in the flat schema via `field_group_id` pointing at the switch's
+ * id). Initial collapsed state comes from `collapsed`.
+ */
+export const CollapsibleSwitch: Story = {
+    args: {
+        schema: collapsibleSwitchSchema,
+        title: 'Integrations',
+        hookPrefix: 'my_plugin',
+    },
+    render: (args) => <SettingsStoryWrapper {...args} />,
+};

--- a/src/components/settings/field-renderer.tsx
+++ b/src/components/settings/field-renderer.tsx
@@ -1,6 +1,11 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Switch } from '../ui';
 import type { SettingsElement, FieldComponentProps } from './settings-types';
 import { useSettings } from './settings-context';
 import {
+    FieldWrapper,
     TextField,
     NumberField,
     TextareaField,
@@ -69,6 +74,13 @@ export function FieldRenderer({
 
     // Dispatch by variant — each wrapped with applyFilters
     switch (variant) {
+        case 'collapsible_switch':
+            return applyFilters(
+                `${filterPrefix}_settings_collapsible_switch_field`,
+                <CollapsibleSwitchField element={mergedElement} isNested={isNested} isGroupParent={isGroupParent} />,
+                mergedElement
+            );
+
         case 'switch_group': {
             const isEnabled = element.enable_state
                 ? mergedElement.value === element.enable_state.value
@@ -264,4 +276,76 @@ export function FieldRenderer({
                 mergedElement
             );
     }
+}
+
+// ============================================
+// Collapsible Switch Field
+// ============================================
+//
+// A row with BOTH a toggle and a chevron in its header (icon + title +
+// description via FieldWrapper), revealing its nested children when expanded.
+// The toggle persists the field value; the chevron controls a local
+// expand/collapse state (default from `element.collapsed`, defaulting to
+// collapsed). Children attach in the flat schema via `field_group_id` pointing
+// at this element's id.
+function CollapsibleSwitchField({
+    element,
+    isNested,
+    isGroupParent,
+}: {
+    element: SettingsElement;
+    isNested?: boolean;
+    isGroupParent?: boolean;
+}) {
+    const { updateValue } = useSettings();
+    const [open, setOpen] = useState( element.collapsed === false );
+
+    const isEnabled = element.enable_state
+        ? element.value === element.enable_state.value
+        : Boolean( element.value );
+
+    const childCount = element.children?.length ?? 0;
+    const hasChildren = childCount > 0;
+    const bodyVisible = open && hasChildren;
+
+    const handleChange = ( checked: boolean ) => {
+        if ( element.enable_state && element.disable_state ) {
+            updateValue( element.id, checked ? element.enable_state.value : element.disable_state.value );
+        } else {
+            updateValue( element.id, checked );
+        }
+    };
+
+    return (
+        <div className="flex flex-col">
+            <FieldWrapper element={ element } isNested={ isNested } isGroupParent={ isGroupParent || bodyVisible }>
+                <div className="flex items-center gap-3 sm:justify-end">
+                    <Switch
+                        checked={ isEnabled }
+                        onCheckedChange={ handleChange }
+                        disabled={ element.disabled }
+                    />
+                    { hasChildren && (
+                        <button
+                            type="button"
+                            onClick={ () => setOpen( ( o ) => ! o ) }
+                            aria-expanded={ open }
+                            aria-label="Toggle details"
+                            className="flex items-center pl-3 border-l border-border text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                            <ChevronDown
+                                className={ cn( 'size-5 transition-transform duration-200', open && 'rotate-180' ) }
+                            />
+                        </button>
+                    ) }
+                </div>
+            </FieldWrapper>
+            { bodyVisible && element.children?.map( ( child ) => (
+                <FieldRenderer
+                    key={ child.id }
+                    element={ child }
+                />
+            ) ) }
+        </div>
+    );
 }

--- a/src/components/settings/fields.tsx
+++ b/src/components/settings/fields.tsx
@@ -1076,7 +1076,7 @@ export function InfoField({ element, ...rest }: FieldComponentProps) {
 
   return (
     <Notice
-      className={ cn( 'bg-primary/10 border-primary mx-4', element.css_class, rest.isNested && "!pt-0 !border-t-0 !border-none", rest.isGroupParent && "!pb-0" ) }
+      className={ cn( 'bg-primary/10 border-primary', element.css_class, rest.isNested && "!pt-0 !border-t-0 !border-none", rest.isGroupParent && "!pb-0" ) }
       id={element.id}
       data-testid={`settings-field-${element.id}`}
     >


### PR DESCRIPTION
## What

Adds a new **`collapsible_switch`** settings field variant and a Storybook story, plus a small `InfoField` alignment fix.

### `collapsible_switch`
A settings field whose header row carries an **icon + title + description + enable toggle + chevron**. It expands to reveal nested config:

- The **toggle** persists the field value (`enable_state` / `disable_state`, like `switch`).
- The **chevron** expands/collapses the field's **nested children** (local UI state; initial value from `collapsed`).
- Children attach in the flat schema via `field_group_id` pointing at the switch's `id`, and render only when expanded.

Implemented as `CollapsibleSwitchField` in `field-renderer.tsx`, dispatched from the variant switch and wrapped with the `${hookPrefix}_settings_collapsible_switch_field` filter (consistent with other variants). Reuses the exported `FieldWrapper` for the header row.

### `InfoField` notice alignment fix
The underlying `Notice` primitive is `w-full`; the extra `mx-4` on `InfoField` pushed every info notice ~16px past its container on the right (asymmetric overflow). Removing `mx-4` makes notices fill their container symmetrically and align with the field column.

### Storybook
Adds **Components/Settings → CollapsibleSwitch**, demoing two providers (Facebook, Google) each with an icon, toggle, chevron, an `info` notice with a `Create an App` link, and nested credential fields.

## Why
Needed for the Dokan vendor-verification "Social Connect" settings, where each social provider is a toggleable, collapsible card with its own credentials.

## Notes
- `build:wp`, `build:types`, and `eslint src` all pass.
- No changes to existing variants/behavior; purely additive (+ the notice margin fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collapsible switch fields for managing grouped settings and integrations. Users can toggle features on/off while expanding/collapsing nested configuration sections, enabling organized control of integration settings and related options.

* **Style**
  * Refined spacing in information field containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->