### PR TITLE
fix(settings/ui): id-keyed dependencies, RadioImageCard layout, rich-text caret

### DIFF
--- a/src/components/settings/settings-formatter.ts
+++ b/src/components/settings/settings-formatter.ts
@@ -334,12 +334,13 @@ export function buildIdIndex(
 /**
  * Evaluates whether a field should be displayed based on its dependencies.
  *
- * Dependency keys are plain field ids (post-dependency_key cleanup). The
- * value is read directly from the flat `values` map keyed by id.
- *
- * `idIndex` is kept as an optional parameter for backwards compatibility with
- * call sites that still pass it; it's unused now that dependency_key is
- * gone and `dep.key` always equals the field id.
+ * Dependency keys are authored as plain field ids. The flat `values` map is
+ * keyed by field id (current contract), so a direct lookup normally resolves.
+ * For resilience against older/alternate payloads that key `values` by the
+ * reconstructed dot-path (e.g. `page.section.field`), the lookup falls back to:
+ *   1. an explicit `idIndex` mapping (field id → stored key), when supplied; then
+ *   2. matching a stored key whose last dot-path segment equals the field id.
+ * This keeps id-keyed dependencies working regardless of how `values` is keyed.
  */
 export function evaluateDependencies(
     element: SettingsElement,
@@ -353,7 +354,18 @@ export function evaluateDependencies(
     return element.dependencies.every((dep) => {
         if (!dep.key) return true;
 
-        const currentValue = values[dep.key];
+        let currentValue = values[dep.key];
+        if (currentValue === undefined) {
+            const mapped = idIndex?.[dep.key];
+            if (mapped !== undefined && values[mapped] !== undefined) {
+                currentValue = values[mapped];
+            } else {
+                const match = Object.keys(values).find(
+                    (k) => k === dep.key || k.split('.').pop() === dep.key
+                );
+                if (match !== undefined) currentValue = values[match];
+            }
+        }
 
         const comparison = dep.comparison || '==';
         const expectedValue = dep.value;

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -143,7 +143,7 @@ function RadioImageCard({
   return (
     <FieldGroup className={cn(disabled && "opacity-50")}>
       <FieldLabel className={cn(
-        "transition-colors has-data-checked:bg-transparent dark:has-data-checked:bg-transparent p-0 group cursor-pointer group",
+        "transition-colors has-data-checked:bg-transparent dark:has-data-checked:bg-transparent p-0 group cursor-pointer rounded-xl overflow-hidden",
         currentValue === props.value && 'border-primary!',
         !disabled && "hover:border-primary"
       )}>
@@ -153,18 +153,18 @@ function RadioImageCard({
           className="flex flex-col p-0!"
           data-testid={`settings-field-${props.id}`}
         >
-          <div className={cn( 'w-full flex flex-row items-center justify-between gap-3 border-b border-border group-hover:border-primary p-3', position === "right" && "flex-row-reverse", currentValue === props.value && 'border-primary!')}>
+          <div className={cn( 'w-full flex flex-row items-center justify-between gap-3 border-b border-border group-hover:border-primary px-5 py-4', position === "right" && "flex-row-reverse", currentValue === props.value && 'border-primary!')}>
             <RadioGroupItem
               className={cn("disabled:opacity-100", className)}
               disabled={disabled}
               {...props}
             />
-            <FieldTitle className="font-bold">
+            <FieldTitle className="font-bold text-base text-foreground">
               {typeof label === 'string' ? <RawHTML>{label}</RawHTML> : label}
             </FieldTitle>
           </div>
-          <FieldContent className={cn('p-3 flex items-center justify-center')} >
-            <div className="flex flex-col items-start gap-3 w-full">
+          <FieldContent className={cn('p-5 flex items-center justify-center')} >
+            <div className="flex flex-col items-center gap-3 w-full">
               {description && (
                 <FieldDescription className="text-center">
                   {description}

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -143,14 +143,19 @@ function RadioImageCard({
   return (
     <FieldGroup className={cn(disabled && "opacity-50")}>
       <FieldLabel className={cn(
-        "transition-colors has-data-checked:bg-transparent dark:has-data-checked:bg-transparent p-0 group cursor-pointer rounded-xl overflow-hidden",
+        // The base FieldLabel injects `*:data-[slot=field]:p-3`, which targets the
+        // child Field with higher specificity than a `p-0!` on the Field itself, so
+        // it can't be overridden there (esp. under the global !important strategy).
+        // Neutralise it at the root via the same child-targeting utility — twMerge
+        // collapses p-3 -> p-0 so the illustration sits flush to the card edges.
+        "transition-colors has-data-checked:bg-transparent dark:has-data-checked:bg-transparent p-0 *:data-[slot=field]:p-0 group cursor-pointer rounded-xl overflow-hidden",
         currentValue === props.value && 'border-primary!',
         !disabled && "hover:border-primary"
       )}>
         <Field
           orientation={orientation}
           data-disabled={disabled}
-          className="flex flex-col p-0!"
+          className="flex flex-col"
           data-testid={`settings-field-${props.id}`}
         >
           <div className={cn( 'w-full flex flex-row items-center justify-between gap-3 border-b border-border group-hover:border-primary px-5 py-4', position === "right" && "flex-row-reverse", currentValue === props.value && 'border-primary!')}>

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -163,7 +163,7 @@ function RadioImageCard({
               {typeof label === 'string' ? <RawHTML>{label}</RawHTML> : label}
             </FieldTitle>
           </div>
-          <FieldContent className={cn('p-5 flex items-center justify-center')} >
+          <FieldContent className={cn('p-0 flex items-center justify-center')} >
             <div className="flex flex-col items-center gap-3 w-full">
               {description && (
                 <FieldDescription className="text-center">

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -163,8 +163,8 @@ function RadioImageCard({
               {typeof label === 'string' ? <RawHTML>{label}</RawHTML> : label}
             </FieldTitle>
           </div>
-          <FieldContent className={cn('p-0 flex items-center justify-center')} >
-            <div className="flex flex-col items-center gap-3 w-full">
+          <FieldContent className={cn('p-0 w-full')} >
+            <div className="flex flex-col gap-3 w-full">
               {description && (
                 <FieldDescription className="text-center">
                   {description}
@@ -172,7 +172,7 @@ function RadioImageCard({
               )}
               {image && (
                 typeof image === 'string' ? (
-                  <img src={image} alt={typeof label === 'string' ? label : 'Option image'} className="w-full h-auto object-contain" />
+                  <img src={image} alt={typeof label === 'string' ? label : 'Option image'} className="block w-full h-auto object-contain" />
                 ) : (
                   image
                 )

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -168,7 +168,7 @@ function RadioImageCard({
               {typeof label === 'string' ? <RawHTML>{label}</RawHTML> : label}
             </FieldTitle>
           </div>
-          <FieldContent className={cn('p-0 w-full')} >
+          <FieldContent className={cn('px-5 py-4 w-full')} >
             <div className="flex flex-col gap-3 w-full">
               {description && (
                 <FieldDescription className="text-center">

--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -52,12 +52,22 @@ function RichTextEditor({
   const [fontFamily, setFontFamily] = React.useState("Sans Serif");
   const [textStyle, setTextStyle] = React.useState("Paragraph");
 
-  // Sync internal content with value prop if it changes and is different
+  // Sync the contentEditable DOM with the value/defaultValue prop.
+  //
+  // The contentEditable is intentionally NOT bound via dangerouslySetInnerHTML:
+  // React would re-apply innerHTML on every keystroke-driven re-render and
+  // collapse the selection to the start, so each typed character appears to
+  // prepend (the "reversed / RTL" typing effect). Here we only write innerHTML
+  // when the incoming content actually differs AND the editor is not focused,
+  // so external/programmatic updates still land but active typing keeps its caret.
   React.useEffect(() => {
-    if (value !== undefined && editorRef.current && value !== editorRef.current.innerHTML) {
-      editorRef.current.innerHTML = value;
-    }
-  }, [value]);
+    const el = editorRef.current;
+    if (!el) return;
+    const next = value ?? defaultValue ?? "";
+    if (next === el.innerHTML) return;
+    if (document.activeElement === el) return;
+    el.innerHTML = next;
+  }, [value, defaultValue]);
 
   const executeCommand = (command: string, value?: string) => {
     document.execCommand(command, false, value);
@@ -315,7 +325,6 @@ function RichTextEditor({
           ref={editorRef}
           contentEditable
           className="w-full h-full px-3 py-2 text-sm outline-none bg-transparent prose prose-sm max-w-none"
-          dangerouslySetInnerHTML={{ __html: value ?? defaultValue }}
           suppressContentEditableWarning
           data-placeholder={placeholder}
           onInput={(e) => {


### PR DESCRIPTION
## Summary

Three independent fixes batched on this branch:

1. **Settings — id-keyed dependency resolution** (`settings-formatter.ts`)
   `evaluateDependencies` now falls back when a direct id lookup misses: first an explicit `idIndex` mapping, then a stored key whose last dot-path segment equals the field id. Keeps id-keyed dependencies working regardless of whether `values` is keyed by id or by reconstructed dot-path.

2. **RadioImageCard layout** (`radio-group.tsx`)
   Illustration now sits flush to the card edges. Neutralises the base `FieldLabel`'s `*:data-[slot=field]:p-3` via the same child-targeting utility (twMerge collapses `p-3` → `p-0`) instead of a `p-0!` that the `!important` strategy couldn't override. Header/content padding bumped to `px-5 py-4`; title uses `text-base text-foreground`.

3. **RichTextEditor caret jump** (`rich-text-editor.tsx`)
   Dropped `dangerouslySetInnerHTML` (re-applied innerHTML every keystroke → caret collapsed to start → reversed/RTL typing). Effect now writes `innerHTML` only when content differs AND editor is not focused, so external updates still land but active typing keeps its caret.

## Test plan

- [x] `npm run lint` (warnings pre-existing in untouched files)
- [x] `npm run typecheck`
- [ ] Verify RadioImageCard illustration flush in Storybook
- [ ] Type in RichTextEditor, confirm caret stays put
- [ ] Toggle a settings dependency, confirm show/hide

🤖 Generated with [Claude Code](https://claude.com/claude-code)