### PR TITLE
feat: add Onboarding stepper component

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build-storybook": "storybook build",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
+    "test": "wp-scripts test-unit-js",
     "prepare": "npm run build"
   },
   "peerDependencies": {

--- a/src/components/onboarding/Onboarding.stories.tsx
+++ b/src/components/onboarding/Onboarding.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { Onboarding } from './index';
+import type { SettingsElement } from '../settings/settings-types';
+
+const stepSchema = (pageId: string, fieldId: string, label: string): SettingsElement[] => [
+    { id: pageId, type: 'page', label },
+    { id: `${pageId}_section`, type: 'section', page_id: pageId, label },
+    {
+        id: fieldId, type: 'field', variant: 'switch', section_id: `${pageId}_section`,
+        label: `${label} toggle`, default: 'on',
+        enable_state: { value: 'on', title: 'Enabled' }, disable_state: { value: 'off', title: 'Disabled' },
+    } as SettingsElement,
+];
+
+const steps = [
+    { id: 'basic', label: 'Basic', schema: stepSchema('basic', 'basic_toggle', 'Basic'), skippable: false, completed: true },
+    { id: 'commission', label: 'Commission', schema: stepSchema('commission', 'commission_toggle', 'Commission'), skippable: true },
+    { id: 'withdraw', label: 'Withdraw', schema: stepSchema('withdraw', 'withdraw_toggle', 'Withdraw'), skippable: true },
+];
+
+const meta = {
+    title: 'Components/Onboarding',
+    component: Onboarding,
+    parameters: { layout: 'fullscreen' },
+    tags: ['autodocs'],
+    args: {
+        onStepSave: fn(),
+    },
+} satisfies Meta<typeof Onboarding>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+    args: { steps, orientation: 'horizontal' },
+};
+
+export const Vertical: Story = {
+    args: { steps, orientation: 'vertical' },
+};
+
+export const CustomIndicator: Story = {
+    args: {
+        steps,
+        orientation: 'horizontal',
+        renderStepIndicator: ({ steps: s, onStepClick }) => (
+            <div className="flex gap-4 p-4">
+                {s.map((step) => (
+                    <button key={step.id} onClick={() => onStepClick(step.id)} className={step.active ? 'font-bold underline' : ''}>
+                        {step.label}
+                    </button>
+                ))}
+            </div>
+        ),
+    },
+};

--- a/src/components/onboarding/Onboarding.stories.tsx
+++ b/src/components/onboarding/Onboarding.stories.tsx
@@ -41,6 +41,14 @@ export const Vertical: Story = {
     args: { steps, orientation: 'vertical' },
 };
 
+export const NoIndicator: Story = {
+    args: {
+        steps,
+        orientation: 'horizontal',
+        renderStepIndicator: () => null,
+    },
+};
+
 export const CustomIndicator: Story = {
     args: {
         steps,

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { SettingsProvider, useSettings } from '../settings/settings-context';
+import type { SettingsElement } from '../settings/settings-types';
+import { StepIndicator } from './step-indicator';
+import { StepFooter } from './step-footer';
+import { StepBody } from './step-body';
+import { isFirstStep, isLastStep, nextStepId, prevStepId } from './onboarding-navigation';
+import type { OnboardingProps } from './onboarding-types';
+
+export function Onboarding({
+    steps,
+    values,
+    activeStepId,
+    orientation = 'horizontal',
+    hookPrefix = 'plugin_ui',
+    applyFilters,
+    loading = false,
+    className,
+    onChange,
+    onStepSave,
+    onStepChange,
+    onSkip,
+    onComplete,
+    renderStepIndicator,
+    renderFooter,
+}: OnboardingProps) {
+    const [internalActive, setInternalActive] = useState<string>(activeStepId ?? steps[0]?.id ?? '');
+    const active = activeStepId ?? internalActive;
+
+    // Merge every step's page subtree into one schema; force hide_save on each
+    // page so SettingsContent suppresses its own save button (footer owns it).
+    const schema = useMemo<SettingsElement[]>(() => {
+        const out: SettingsElement[] = [];
+        for (const step of steps) {
+            for (const el of step.schema) {
+                if (el.type === 'page' && el.id === step.id) {
+                    out.push({ ...el, hide_save: true });
+                } else {
+                    out.push(el);
+                }
+            }
+        }
+        return out;
+    }, [steps]);
+
+    const goTo = (id: string) => {
+        if (activeStepId === undefined) setInternalActive(id);
+        onStepChange?.(id);
+    };
+
+    return (
+        <SettingsProvider
+            schema={schema}
+            values={values}
+            onChange={onChange ? (scopeId, key, value) => onChange(scopeId, key, value) : undefined}
+            onSave={onStepSave}
+            loading={loading}
+            hookPrefix={hookPrefix}
+            applyFilters={applyFilters}
+            initialPage={active}
+        >
+            <OnboardingInner
+                steps={steps}
+                active={active}
+                orientation={orientation}
+                className={className}
+                goTo={goTo}
+                onSkip={onSkip}
+                onComplete={onComplete}
+                renderStepIndicator={renderStepIndicator}
+                renderFooter={renderFooter}
+            />
+        </SettingsProvider>
+    );
+}
+
+function OnboardingInner({
+    steps, active, orientation, className, goTo, onSkip, onComplete, renderStepIndicator, renderFooter,
+}: {
+    steps: OnboardingProps['steps'];
+    active: string;
+    orientation: 'horizontal' | 'vertical';
+    className?: string;
+    goTo: (id: string) => void;
+    onSkip?: OnboardingProps['onSkip'];
+    onComplete?: OnboardingProps['onComplete'];
+    renderStepIndicator?: OnboardingProps['renderStepIndicator'];
+    renderFooter?: OnboardingProps['renderFooter'];
+}) {
+    const { setActivePage, getPageValues, isPageDirty, hasScopeErrors, save } = useSettings();
+
+    const activeStep = steps.find((s) => s.id === active) ?? steps[0];
+    const isFirst = isFirstStep(steps, active);
+    const isLast = isLastStep(steps, active);
+
+    const navigate = (id: string | null) => {
+        if (!id) return;
+        setActivePage(id);
+        goTo(id);
+    };
+
+    const persist = () => {
+        if (hasScopeErrors(active) || !save) return;
+        save(active, getPageValues(active)); // routes to onStepSave(stepId, tree, flat)
+    };
+
+    const indicatorProps = {
+        steps: steps.map((s, index) => ({
+            id: s.id, label: s.label, completed: Boolean(s.completed), active: s.id === active, index,
+        })),
+        orientation,
+        onStepClick: (id: string) => navigate(id),
+    };
+
+    const footerProps = {
+        activeStepId: active,
+        isFirst,
+        isLast,
+        skippable: Boolean(activeStep?.skippable),
+        dirty: isPageDirty(active),
+        hasErrors: hasScopeErrors(active),
+        onBack: () => navigate(prevStepId(steps, active)),
+        onSkip: () => { onSkip?.(active); navigate(nextStepId(steps, active)); },
+        onNext: () => { persist(); navigate(nextStepId(steps, active)); },
+        onFinish: () => { persist(); onComplete?.(); },
+    };
+
+    const horizontal = orientation === 'horizontal';
+
+    return (
+        <div
+            data-testid="onboarding-root"
+            className={cn('rounded-lg border border-border bg-background overflow-hidden', horizontal ? 'flex flex-col' : 'flex flex-row', className)}
+        >
+            {renderStepIndicator ? renderStepIndicator(indicatorProps) : <StepIndicator {...indicatorProps} />}
+            <div className="flex flex-1 min-w-0 flex-col">
+                <StepBody />
+                {renderFooter ? renderFooter(footerProps) : <StepFooter {...footerProps} />}
+            </div>
+        </div>
+    );
+}
+
+export type { OnboardingProps, OnboardingStep } from './onboarding-types';

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -100,9 +100,9 @@ function OnboardingInner({
         goTo(id);
     };
 
-    const persist = () => {
+    const persist = async () => {
         if (hasScopeErrors(active) || !save) return;
-        save(active, getPageValues(active)); // routes to onStepSave(stepId, tree, flat)
+        await save(active, getPageValues(active)); // routes to onStepSave(stepId, tree, flat)
     };
 
     const indicatorProps = {
@@ -122,8 +122,8 @@ function OnboardingInner({
         hasErrors: hasScopeErrors(active),
         onBack: () => navigate(prevStepId(steps, active)),
         onSkip: () => { onSkip?.(active); navigate(nextStepId(steps, active)); },
-        onNext: () => { persist(); navigate(nextStepId(steps, active)); },
-        onFinish: () => { persist(); onComplete?.(); },
+        onNext: async () => { await persist(); navigate(nextStepId(steps, active)); },
+        onFinish: async () => { await persist(); onComplete?.(); },
     };
 
     const horizontal = orientation === 'horizontal';

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -30,6 +30,8 @@ export function Onboarding({
 
     // Merge every step's page subtree into one schema; force hide_save on each
     // page so SettingsContent suppresses its own save button (footer owns it).
+    // NOTE: callers should pass a stable `steps` reference (useMemo or a
+    // module-level constant) to avoid rebuilding the merged schema each render.
     const schema = useMemo<SettingsElement[]>(() => {
         const out: SettingsElement[] = [];
         for (const step of steps) {
@@ -53,7 +55,7 @@ export function Onboarding({
         <SettingsProvider
             schema={schema}
             values={values}
-            onChange={onChange ? (scopeId, key, value) => onChange(scopeId, key, value) : undefined}
+            onChange={onChange}
             onSave={onStepSave}
             loading={loading}
             hookPrefix={hookPrefix}

--- a/src/components/onboarding/onboarding-navigation.test.ts
+++ b/src/components/onboarding/onboarding-navigation.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from '@jest/globals';
+import { stepIndexOf, nextStepId, prevStepId, isFirstStep, isLastStep } from './onboarding-navigation';
+
+const steps = [ { id: 'basic' }, { id: 'commission' }, { id: 'withdraw' }, { id: 'appearance' } ];
+
+describe( 'onboarding-navigation', () => {
+	it( 'resolves index of a step id', () => {
+		expect( stepIndexOf( steps, 'withdraw' ) ).toBe( 2 );
+		expect( stepIndexOf( steps, 'missing' ) ).toBe( -1 );
+	} );
+
+	it( 'advances and retreats within bounds', () => {
+		expect( nextStepId( steps, 'basic' ) ).toBe( 'commission' );
+		expect( nextStepId( steps, 'appearance' ) ).toBeNull(); // already last
+		expect( prevStepId( steps, 'commission' ) ).toBe( 'basic' );
+		expect( prevStepId( steps, 'basic' ) ).toBeNull(); // already first
+	} );
+
+	it( 'reports boundaries', () => {
+		expect( isFirstStep( steps, 'basic' ) ).toBe( true );
+		expect( isLastStep( steps, 'appearance' ) ).toBe( true );
+		expect( isLastStep( steps, 'withdraw' ) ).toBe( false );
+	} );
+
+	it( 'treats an unknown active id as no movement', () => {
+		expect( nextStepId( steps, 'missing' ) ).toBeNull();
+		expect( prevStepId( steps, 'missing' ) ).toBeNull();
+	} );
+} );

--- a/src/components/onboarding/onboarding-navigation.ts
+++ b/src/components/onboarding/onboarding-navigation.ts
@@ -1,0 +1,26 @@
+export type StepRef = { id: string };
+
+export function stepIndexOf( steps: StepRef[], id: string ): number {
+	return steps.findIndex( ( s ) => s.id === id );
+}
+
+export function nextStepId( steps: StepRef[], current: string ): string | null {
+	const i = stepIndexOf( steps, current );
+	if ( i < 0 || i >= steps.length - 1 ) return null;
+	return steps[ i + 1 ].id;
+}
+
+export function prevStepId( steps: StepRef[], current: string ): string | null {
+	const i = stepIndexOf( steps, current );
+	if ( i <= 0 ) return null;
+	return steps[ i - 1 ].id;
+}
+
+export function isFirstStep( steps: StepRef[], id: string ): boolean {
+	return stepIndexOf( steps, id ) === 0;
+}
+
+export function isLastStep( steps: StepRef[], id: string ): boolean {
+	const i = stepIndexOf( steps, id );
+	return i >= 0 && i === steps.length - 1;
+}

--- a/src/components/onboarding/onboarding-types.ts
+++ b/src/components/onboarding/onboarding-types.ts
@@ -12,7 +12,15 @@ export interface OnboardingStep {
     label?: string;
     description?: string;
     icon?: string;
-    schema: SettingsElement[];  // page subtree: [{id, type:'page'}, sections…, fields…]
+    /**
+     * The step's settings elements as a page subtree:
+     * `[{ id, type: 'page' }, ...sections, ...fields]`.
+     *
+     * NOTE: all steps are merged into ONE flat provider schema, so field ids
+     * must be globally unique across the ENTIRE wizard (not just within a step).
+     * Duplicate field ids across steps collide silently in the shared values map.
+     */
+    schema: SettingsElement[];
     skippable?: boolean;
     completed?: boolean;
 }

--- a/src/components/onboarding/onboarding-types.ts
+++ b/src/components/onboarding/onboarding-types.ts
@@ -1,0 +1,55 @@
+// ============================================
+// Onboarding Component Types
+// ============================================
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { ReactNode } from 'react';
+import type { SettingsElement } from '../settings/settings-types';
+import type { ApplyFiltersFunction } from '../settings/settings-context';
+
+export interface OnboardingStep {
+    id: string;                 // also the page id inside schema
+    label?: string;
+    description?: string;
+    icon?: string;
+    schema: SettingsElement[];  // page subtree: [{id, type:'page'}, sections…, fields…]
+    skippable?: boolean;
+    completed?: boolean;
+}
+
+export interface StepIndicatorRenderProps {
+    steps: Array<{ id: string; label?: string; completed?: boolean; active: boolean; index: number; }>;
+    orientation: 'horizontal' | 'vertical';
+    onStepClick: (stepId: string) => void;
+}
+
+export interface StepFooterRenderProps {
+    activeStepId: string;
+    isFirst: boolean;
+    isLast: boolean;
+    skippable: boolean;
+    dirty: boolean;
+    hasErrors: boolean;
+    onBack: () => void;
+    onSkip: () => void;
+    onNext: () => void;   // saves current step, then advances
+    onFinish: () => void; // saves last step, then completes
+}
+
+export interface OnboardingProps {
+    steps: OnboardingStep[];
+    values?: Record<string, any>;
+    activeStepId?: string;                              // controlled; falls back to first step
+    orientation?: 'horizontal' | 'vertical';           // default 'horizontal'
+    hookPrefix?: string;                                // default 'plugin_ui'
+    applyFilters?: ApplyFiltersFunction;
+    loading?: boolean;
+    className?: string;
+    onChange?: (stepId: string, key: string, value: any) => void;
+    onStepSave?: (stepId: string, treeValues: Record<string, any>, flatValues: Record<string, any>) => void | Promise<void>;
+    onStepChange?: (stepId: string) => void;
+    onSkip?: (stepId: string) => void;
+    onComplete?: () => void;
+    renderStepIndicator?: (props: StepIndicatorRenderProps) => ReactNode;
+    renderFooter?: (props: StepFooterRenderProps) => ReactNode;
+}

--- a/src/components/onboarding/onboarding-types.ts
+++ b/src/components/onboarding/onboarding-types.ts
@@ -32,8 +32,8 @@ export interface StepFooterRenderProps {
     hasErrors: boolean;
     onBack: () => void;
     onSkip: () => void;
-    onNext: () => void;   // saves current step, then advances
-    onFinish: () => void; // saves last step, then completes
+    onNext: () => void | Promise<void>;   // saves current step, then advances
+    onFinish: () => void | Promise<void>; // saves last step, then completes
 }
 
 export interface OnboardingProps {

--- a/src/components/onboarding/step-body.tsx
+++ b/src/components/onboarding/step-body.tsx
@@ -1,0 +1,6 @@
+import { SettingsContent } from '../settings/settings-content';
+import { cn } from '@/lib/utils';
+
+export function StepBody({ className }: { className?: string }) {
+    return <SettingsContent className={cn('flex-1', className)} />;
+}

--- a/src/components/onboarding/step-footer.tsx
+++ b/src/components/onboarding/step-footer.tsx
@@ -1,0 +1,37 @@
+import { Button } from '../ui/button';
+import type { StepFooterRenderProps } from './onboarding-types';
+
+export function StepFooter({
+    isFirst, isLast, skippable, dirty, hasErrors, onBack, onSkip, onNext, onFinish,
+}: StepFooterRenderProps) {
+    return (
+        <div
+            data-testid="onboarding-step-footer"
+            className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-border bg-background px-6 py-3"
+        >
+            <div>
+                {!isFirst && (
+                    <Button variant="ghost" onClick={onBack} data-testid="onboarding-back">
+                        Back
+                    </Button>
+                )}
+            </div>
+            <div className="flex items-center gap-2">
+                {skippable && !isLast && (
+                    <Button variant="outline" onClick={onSkip} data-testid="onboarding-skip">
+                        Skip
+                    </Button>
+                )}
+                {isLast ? (
+                    <Button onClick={onFinish} disabled={hasErrors} data-testid="onboarding-finish">
+                        Finish
+                    </Button>
+                ) : (
+                    <Button onClick={onNext} disabled={hasErrors} data-testid="onboarding-next">
+                        Continue
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/onboarding/step-footer.tsx
+++ b/src/components/onboarding/step-footer.tsx
@@ -2,7 +2,7 @@ import { Button } from '../ui/button';
 import type { StepFooterRenderProps } from './onboarding-types';
 
 export function StepFooter({
-    isFirst, isLast, skippable, dirty, hasErrors, onBack, onSkip, onNext, onFinish,
+    isFirst, isLast, skippable, hasErrors, onBack, onSkip, onNext, onFinish,
 }: StepFooterRenderProps) {
     return (
         <div

--- a/src/components/onboarding/step-indicator.tsx
+++ b/src/components/onboarding/step-indicator.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils';
+import { Check } from 'lucide-react';
+import type { StepIndicatorRenderProps } from './onboarding-types';
+
+export function StepIndicator({ steps, orientation, onStepClick }: StepIndicatorRenderProps) {
+    const horizontal = orientation === 'horizontal';
+    return (
+        <ol
+            data-testid="onboarding-step-indicator"
+            className={cn(
+                'flex gap-2',
+                horizontal ? 'flex-row items-center justify-center flex-wrap p-4' : 'flex-col p-4 w-56 shrink-0'
+            )}
+        >
+            {steps.map((step) => (
+                <li key={step.id} className={cn('flex items-center gap-3', horizontal ? '' : 'w-full')}>
+                    <button
+                        type="button"
+                        onClick={() => onStepClick(step.id)}
+                        data-testid={`onboarding-step-${step.id}`}
+                        aria-current={step.active ? 'step' : undefined}
+                        className={cn(
+                            'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors w-full text-left',
+                            step.active ? 'bg-primary/10 text-primary font-semibold' : 'text-muted-foreground hover:bg-muted/40'
+                        )}
+                    >
+                        <span
+                            className={cn(
+                                'flex size-6 shrink-0 items-center justify-center rounded-full border text-xs',
+                                step.completed ? 'border-primary bg-primary text-primary-foreground'
+                                    : step.active ? 'border-primary text-primary' : 'border-border'
+                            )}
+                        >
+                            {step.completed ? <Check className="size-3.5" /> : step.index + 1}
+                        </span>
+                        {step.label && <span className="truncate">{step.label}</span>}
+                    </button>
+                </li>
+            ))}
+        </ol>
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,6 +386,15 @@ export {
 } from './components/settings';
 export { SettingsSkeleton } from './components/settings/settings-skeleton';
 
+// Onboarding (schema-driven setup wizard)
+export { Onboarding } from './components/onboarding';
+export type {
+    OnboardingProps,
+    OnboardingStep,
+    StepIndicatorRenderProps,
+    StepFooterRenderProps,
+} from './components/onboarding/onboarding-types';
+
 // ============================================
 // Theme Presets
 // ============================================


### PR DESCRIPTION
## Summary

Adds a reusable, schema-driven **`<Onboarding>`** stepper component to `@wedevs/plugin-ui`. It reuses the existing settings infrastructure (`SettingsProvider`, `SettingsContent`, `FieldRenderer`, dependency evaluation, `applyFilters` field hooks) and only replaces the chrome: the sidebar becomes a step indicator, and the per-scope save button becomes stepper navigation (Back / Skip / Continue / Finish).

- Each `OnboardingStep.schema` is a "page" subtree; navigating the stepper drives the provider's active page.
- Step save routes `onNext/onFinish → save(active, getPageValues(active)) → provider handleOnSave → consumer onStepSave(stepId, treeValues, flatValues)` (awaited before navigating/completing).
- `orientation` supports **horizontal** and **vertical**; the indicator and footer are fully overridable via `renderStepIndicator` / `renderFooter` render props.
- Fields render through the exact same `FieldRenderer` as the Settings page, so a consuming wizard stays pixel-consistent with its settings UI.

### Files
- `src/components/onboarding/` — `onboarding-navigation.ts` (+ test), `onboarding-types.ts`, `step-indicator.tsx`, `step-footer.tsx`, `step-body.tsx`, `index.tsx`, `Onboarding.stories.tsx`
- `src/index.ts` — exports `Onboarding` + types
- `package.json` — adds `test` script (`wp-scripts test-unit-js`)

This is the first of two PRs; the consumer side (Dokan Lite onboarding wizard converging onto this component + the flat settings schema) lands separately.

## Test Plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` (onboarding + index) — clean
- [x] `wp-scripts test-unit-js src/components/onboarding` — 4/4 pass
- [x] `npm run build` — succeeds; `Onboarding` present in `dist/index.d.ts` + bundle
- [x] `npm run build-storybook` — succeeds
- [ ] Review the 4 stories under **Components → Onboarding** (Horizontal, Vertical, NoIndicator, CustomIndicator)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a multi-step onboarding component with horizontal and vertical orientation support.
  * Features customizable step indicators, navigation footer with back/skip/next/finish controls, and optional custom renderers.

* **Tests**
  * Added test coverage for step navigation utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->